### PR TITLE
Bound Neo4j queries + View6 network-connections graph + View2 signal highlight

### DIFF
--- a/protostar-ai-dev-flask-api/services/telemetryservice.py
+++ b/protostar-ai-dev-flask-api/services/telemetryservice.py
@@ -50,8 +50,8 @@ class TelemetryService:
   def get_view1(self):
     try:
       with(self.neo4j_driver.session()) as session:
-        result = session.run("""MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n 
-        MATCH path = (n)-[*]->(:ALERT)
+        result = session.run("""MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n
+        MATCH path = (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(:ALERT)
         where not n.entity = "172.16.200.110" RETURN path""")
         data = result.data()
         # print(data.pop().pop())
@@ -69,7 +69,7 @@ class TelemetryService:
       result_df = neo4j.query(f"""
         MATCH (n:ENTITY)
           WHERE n.view = 2
-          MATCH (n)-[*]->(m:ALERT)
+          MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
         RETURN DISTINCT
           substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity
         ORDER BY entity ASC
@@ -87,7 +87,7 @@ class TelemetryService:
       result_df = neo4j.query(f"""
         MATCH (n:ENTITY)
           WHERE n.view = 2
-          MATCH (n)-[*]->(m:ALERT)
+          MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
           where n.entity contains '{entity}'
           RETURN
               m.detection_type AS detection_type,
@@ -109,7 +109,7 @@ class TelemetryService:
       query = f"""
       MATCH (n:ENTITY)
         WHERE n.view = 2
-        MATCH (n)-[*]->(m:ALERT)
+        MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
         where m.detection_type contains '{detection_type}'
       RETURN
         m.detection_type AS detection_type,
@@ -134,7 +134,7 @@ class TelemetryService:
       query = f"""
         MATCH (n:ENTITY)
           WHERE n.view = 2
-          MATCH (n)-[*]->(m:ALERT)
+          MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
           where n.entity contains '{entity}'
           RETURN
               substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity,
@@ -179,7 +179,7 @@ class TelemetryService:
         AND m.view = 1 WITH n, collect(DISTINCT type(r))
         AS relTypes, collect(r) AS relationships, collect(m)
         AS relatedNodes, elementId(n) as elementId WHERE size(relTypes) >= 2
-        OPTIONAL MATCH (n2:ENTITY {view: 2, entity: n.entity})-[*]->(a:ALERT)
+        OPTIONAL MATCH (n2:ENTITY {view: 2, entity: n.entity})-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(a:ALERT)
         WITH n, relTypes, relationships, relatedNodes, elementId,
         count(DISTINCT a.detection_type) AS atomicNumber,
         count(a) AS atomicMass,
@@ -210,10 +210,10 @@ class TelemetryService:
     data = []
     try:
       neo4j = self.neo4j_driver
-      result_df = neo4j.query("""MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n 
-      MATCH path = (n)-[*]->(a:ALERT) where 
-      not n.entity = "172.16.200.110" 
-      and (a.detection_type = "CLOUD_ANOMALY" 
+      result_df = neo4j.query("""MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n
+      MATCH path = (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(a:ALERT) where
+      not n.entity = "172.16.200.110"
+      and (a.detection_type = "CLOUD_ANOMALY"
       or a.detection_type = "CLOUD_ALERT") RETURN path""").to_data_frame()
       data = result_df.to_json()
     except Exception as e:
@@ -224,9 +224,9 @@ class TelemetryService:
     data = []
     try:
       neo4j = self.neo4j_driver
-      result_df = neo4j.query("""MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n 
-      MATCH path = (n)-[*]->(a:ALERT) 
-      where not n.entity = "172.16.200.110" 
+      result_df = neo4j.query("""MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n
+      MATCH path = (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(a:ALERT)
+      where not n.entity = "172.16.200.110"
       and not (a.detection_type = "CLOUD_ANOMALY" 
       or a.detection_type = "CLOUD_ALERT") RETURN path""").to_data_frame()
       data = result_df.to_json()

--- a/protostar-neo/src/common/types/backend-models.ts
+++ b/protostar-neo/src/common/types/backend-models.ts
@@ -6,6 +6,8 @@ export interface EntityNodeData {
   source_ip: string,
   dest_ip: string,
   count: number,
+  connection_count?: number, // view 6: distinct peer hosts
+  entity_links?: number,     // view 6: entity-to-entity connection count (highlight when > 0)
 };
 
 export interface SeverityClusterNodeData {

--- a/protostar-neo/src/components/NetworkGraph/NetworkGraph.tsx
+++ b/protostar-neo/src/components/NetworkGraph/NetworkGraph.tsx
@@ -12,6 +12,8 @@ export enum NodeGroup {
   LOW_SEVERITY = 5,
   MEDIUM_SEVERITY = 6,
   HIGH_SEVERITY = 7,
+  HOST = 8,
+  CONNECTED_ENTITY = 9, // entity that connects to another entity (view 6 highlight)
 }
 
 export enum NodeType {
@@ -19,6 +21,7 @@ export enum NodeType {
   SEVERITY_CLUSTER = 'SEVERITY_CLUSTER',
   NAME_CLUSTER = 'NAME_CLUSTER',
   ALERT = 'ALERT',
+  HOST = 'HOST',
 }
 
 export interface Node extends d3.SimulationNodeDatum {
@@ -41,6 +44,7 @@ type Props = {
   height: number | string;
   strength: number;
   labelNodeTypes?: NodeType[keyof NodeType][]
+  directed?: boolean // draw arrowheads to indicate edge direction (source -> target)
 };
 
 const ForceGraph: React.FC<Props> = ({
@@ -50,6 +54,7 @@ const ForceGraph: React.FC<Props> = ({
   height,
   strength,
   labelNodeTypes = ['ENTITY', 'SEVERITY_CLUSTER', 'NAME_CLUSTER'], // default nodes to be labelled, override this prop to label other node types
+  directed = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -62,6 +67,7 @@ const ForceGraph: React.FC<Props> = ({
         nodes,
         strength,
         labelNodeTypes,
+        directed,
       );
       destroyFn = destroy;
     }

--- a/protostar-neo/src/components/NetworkGraph/runForceGraph.js
+++ b/protostar-neo/src/components/NetworkGraph/runForceGraph.js
@@ -9,6 +9,8 @@ const COLOR_MAP = {
   5: '#ffbaac',   // LOW    severity ALERT
   6: '#ff9585',   // MEDIUM severity ALERT
   7: '#ff584d',   // HIGH   severity ALERT
+  8: 'white',     // host node (view 6)
+  9: '#ff584d',   // entity connected to another entity (view 6 highlight)
 };
 
 function wrap() {
@@ -23,6 +25,9 @@ function wrap() {
 }
 
 function getDynamicLabel(node) {
+  if (node.type === 'HOST') {
+    return node.ip ?? '';
+  }
   if (node.view === 2 && node.type === 'SEVERITY_CLUSTER') {
     return `[${node.entity_type}] ${node.entity} (${node.severity})`
   }
@@ -35,6 +40,7 @@ export function runForceGraph(
   nodesData,
   strength,
   labelNodeTypes, // list of nodetypes to attach a label to
+  directed = false, // draw arrowheads indicating edge direction (source -> target)
 ) {
   const nodes = nodesData;
   const hostNodes = nodesData.filter(node => node.type === 'ENTITY');
@@ -129,6 +135,22 @@ export function runForceGraph(
         ]),
     );
 
+  if (directed) {
+    svg
+      .append('defs')
+      .append('marker')
+      .attr('id', 'arrowhead')
+      .attr('viewBox', '0 -5 10 10')
+      .attr('refX', 10)
+      .attr('refY', 0)
+      .attr('markerWidth', 7)
+      .attr('markerHeight', 7)
+      .attr('orient', 'auto')
+      .append('path')
+      .attr('d', 'M0,-5L10,0L0,5')
+      .attr('fill', '#999');
+  }
+
   const link = svg
     .append('g')
     .selectAll('line')
@@ -137,6 +159,7 @@ export function runForceGraph(
     .append('line')
     .attr('stroke', '#999')
     .attr('stroke-opacity', 0.6)
+    .attr('marker-end', directed ? 'url(#arrowhead)' : null)
 
   const node = svg
     .append('g')
@@ -144,8 +167,9 @@ export function runForceGraph(
     .data(alertNodes)
     .join('circle')
     .attr('r', (d) =>
-      Math.sqrt(2) *
-      Math.max(1, Math.log(isNaN(d.count) ? 1 : d.count * 20)),
+      d.type === 'HOST'
+        ? 6
+        : Math.sqrt(2) * Math.max(1, Math.log(isNaN(d.count) ? 1 : d.count * 20)),
     )
     .attr('fill', (d) => COLOR_MAP[d.group])
     .on('click', (event, d) => {
@@ -184,7 +208,7 @@ export function runForceGraph(
     // .each(wrap) // this truncates the host label
     .attr('stroke', '#000')
     .attr('stroke-width', 1)
-    .attr('fill', '#ff9585')
+    .attr('fill', (d) => COLOR_MAP[d.group]) // match the node color (white, or red when entity-linked)
     .attr('font-size', '20')
     .attr('font-weight', '900')
     .attr('text-anchor', 'middle')
@@ -209,8 +233,20 @@ export function runForceGraph(
     link
       .attr('x1', (d) => d.source.x)
       .attr('y1', (d) => d.source.y)
-      .attr('x2', (d) => d.target.x)
-      .attr('y2', (d) => d.target.y);
+      .attr('x2', (d) => {
+        if (!directed) return d.target.x;
+        const dx = d.target.x - d.source.x, dy = d.target.y - d.source.y;
+        const len = Math.hypot(dx, dy) || 1;
+        const pad = d.target.type === 'HOST' ? 12 : 16; // node radius + arrow
+        return d.target.x - (dx / len) * pad;
+      })
+      .attr('y2', (d) => {
+        if (!directed) return d.target.y;
+        const dx = d.target.x - d.source.x, dy = d.target.y - d.source.y;
+        const len = Math.hypot(dx, dy) || 1;
+        const pad = d.target.type === 'HOST' ? 12 : 16;
+        return d.target.y - (dy / len) * pad;
+      });
 
     // update node positions
     node.attr('cx', (d) => d.x).attr('cy', (d) => d.y).transition()

--- a/protostar-neo/src/hooks/useGetEntityDetail/useGetEntityDetailData.ts
+++ b/protostar-neo/src/hooks/useGetEntityDetail/useGetEntityDetailData.ts
@@ -10,7 +10,7 @@ export function useGetEntityDetailData()
     const entityDetailResponse = await axios.post<DataGraphResponse<NodeData>>(`${dbURL}/tx/commit`, JSON.stringify({
       statements: [
         {
-          statement: `MATCH path = (n:ENTITY)-[r*]->(m) where n.view = 1 and m.view = 1 and n.entity = "${entityName}" return path`,
+          statement: `MATCH path = (n:ENTITY)-[r*..2]->(m) where n.view = 1 and m.view = 1 and n.entity = "${entityName}" return path`,
         },
       ],
     }), {

--- a/protostar-neo/src/pages/Dashboard/Experimental/View4.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View4.tsx
@@ -24,7 +24,7 @@ export function View4()
             statement: `MATCH (n:ENTITY {view: 1})-[r]->(m {view: 1})
                         WITH n, count(r) AS count_of_first_layer_nodes
                         WHERE count_of_first_layer_nodes = 2
-                        MATCH p=(n)-[r*]->(m)
+                        MATCH p=(n)-[r*..2]->(m)
                         RETURN p`,
           },
         ],

--- a/protostar-neo/src/pages/Dashboard/Experimental/View5.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View5.tsx
@@ -24,7 +24,7 @@ export function View5()
             statement: `MATCH (n:ENTITY {view: 1})-[r]->(m {view: 1})
                         WITH n, count(r) AS count_of_first_layer_nodes
                         WHERE count_of_first_layer_nodes = 1
-                        MATCH p=(n)-[r*]->(m)
+                        MATCH p=(n)-[r*..2]->(m)
                         RETURN p`,
           },
         ],

--- a/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
@@ -21,7 +21,7 @@ export function View6()
       body: JSON.stringify({
         statements: [
           {
-            statement: `MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n MATCH path = (n)-[*]->(a:ALERT) where (a.detection_type = "SIGNAL" or a.detection_type = "ML_CORRELATION") RETURN path`
+            statement: `MATCH path = ()-[:CONNECTS_HOST {view: 6}]->() RETURN path UNION MATCH path = (:ENTITY {view: 2})-[:CONNECTS_TO {view: 6}]->(:ENTITY {view: 2}) RETURN path`
           },
         ],
       }),
@@ -45,7 +45,8 @@ export function View6()
         width={"100%"}
         height={"90vh"}
         strength={-500}
-        labelNodeTypes={['SEVERITY_CLUSTER']}
+        labelNodeTypes={['ENTITY', 'HOST']}
+        directed
       />
     </div>
   );

--- a/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
@@ -44,7 +44,7 @@ export function View6()
         links={network.links ?? []}
         width={"100%"}
         height={"90vh"}
-        strength={-5000}
+        strength={-50}
         labelNodeTypes={['ENTITY', 'HOST']}
         directed
       />

--- a/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
@@ -44,7 +44,7 @@ export function View6()
         links={network.links ?? []}
         width={"100%"}
         height={"90vh"}
-        strength={-1400}
+        strength={-1300}
         labelNodeTypes={['ENTITY', 'HOST']}
         directed
       />

--- a/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
@@ -44,7 +44,7 @@ export function View6()
         links={network.links ?? []}
         width={"100%"}
         height={"90vh"}
-        strength={-50}
+        strength={-1400}
         labelNodeTypes={['ENTITY', 'HOST']}
         directed
       />

--- a/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
@@ -44,7 +44,7 @@ export function View6()
         links={network.links ?? []}
         width={"100%"}
         height={"90vh"}
-        strength={-500}
+        strength={-5000}
         labelNodeTypes={['ENTITY', 'HOST']}
         directed
       />

--- a/protostar-neo/src/pages/Dashboard/View1.tsx
+++ b/protostar-neo/src/pages/Dashboard/View1.tsx
@@ -22,7 +22,7 @@ export function View1()
       body: JSON.stringify({
         statements: [
           {
-            statement: `MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n MATCH path = (n)-[*]->(:ALERT) where not n.entity = "172.16.200.110" RETURN path`
+            statement: `MATCH (n:ENTITY) WHERE n.view = 2 WITH DISTINCT n MATCH path = (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(:ALERT) where not n.entity = "172.16.200.110" RETURN path`
           },
         ],
       }),

--- a/protostar-neo/src/pages/Dashboard/View2.tsx
+++ b/protostar-neo/src/pages/Dashboard/View2.tsx
@@ -22,7 +22,7 @@ export function View2()
       body: JSON.stringify({
         statements: [
           {
-            statement: `MATCH (h:ENTITY)-[r]->() WHERE NOT type(r) IN ['AS_SOURCE', 'AS_DEST'] WITH h, collect(DISTINCT type(r)) AS relationshipTypes WHERE size(relationshipTypes) >= 3 and h.view = 1 MATCH p=(h)-[r*]->() RETURN p`,
+            statement: `MATCH (h:ENTITY)-[r]->() WHERE NOT type(r) IN ['AS_SOURCE', 'AS_DEST'] WITH h, collect(DISTINCT type(r)) AS relationshipTypes WHERE size(relationshipTypes) >= 3 and h.view = 1 MATCH p=(h)-[r*..2]->() RETURN p`,
           },
         ],
       }),

--- a/protostar-neo/src/pages/Dashboard/View2.tsx
+++ b/protostar-neo/src/pages/Dashboard/View2.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { IGraphData, processNodesAndEdges } from './graphUtils';
-import ForceGraph from "../../components/NetworkGraph/NetworkGraph";
+import ForceGraph, { NodeType, NodeGroup } from "../../components/NetworkGraph/NetworkGraph";
 
 
 export function View2() 
@@ -35,7 +35,18 @@ export function View2()
   }, []);
 
   useEffect(() => {
-    setNetwork(processNodesAndEdges(graphData));
+    const net = processNodesAndEdges(graphData);
+    // View2-only highlight: red any entity that has a 'signal' or 'correlation'
+    // relationship (its neighbouring _SET node's detection_type matches). The
+    // relationship type itself isn't visible to the frontend, but the _SET node's
+    // detection_type is. Scoped here so it does not affect other pages.
+    const signalRe = /signal|correlation/i;
+    (net.links ?? []).forEach((l: any) => {
+      if (l.source?.type === NodeType.ENTITY && signalRe.test(l.target?.detection_type ?? '')) {
+        l.source.group = NodeGroup.HIGH_SEVERITY; // red
+      }
+    });
+    setNetwork(net);
   }, [graphData]);
 
   return (

--- a/protostar-neo/src/pages/Dashboard/graphUtils.ts
+++ b/protostar-neo/src/pages/Dashboard/graphUtils.ts
@@ -10,6 +10,10 @@ export type ElementID = string;
 export function getTypeFromNodeInfo(nodeMeta: NodeMeta, nodeData: NodeData) {
     const isView2 = nodeData.view === 2;
     switch (true) {
+        // case for Host node (view 6 network-connections overlay: has ip, no entity)
+        case nodeData.view === 6:
+            return NodeType.HOST;
+
         // case for Alert node
         case isView2 && nodeMeta.type === "node" && nodeData.detection_type !== undefined:
             return NodeType.ALERT;
@@ -37,6 +41,14 @@ export function getTypeFromNodeInfo(nodeMeta: NodeMeta, nodeData: NodeData) {
 export function getGroupFromNodeInfo(nodeMeta: NodeMeta, nodeData: NodeData) {
     const isView2 = nodeData.view === 2;
     switch (true) {
+        // case for Host node (view 6 network-connections overlay)
+        case nodeData.view === 6:
+            return NodeGroup.HOST;
+
+        // view 6 highlight: entity that connects to another entity (e.g. LP-42 <-> lp-sre-42)
+        case (nodeData.entity_links ?? 0) > 0:
+            return NodeGroup.CONNECTED_ENTITY;
+
         // case for Alert node
         case isView2 && nodeMeta.type === "node" &&
             nodeData.detection_type !== undefined:

--- a/protostar-react/src/components/Menu.tsx
+++ b/protostar-react/src/components/Menu.tsx
@@ -35,7 +35,7 @@ export function Menu()
     { id: 5, label: 'Gamma Signals', link: '/view5', element: <View5 /> },
     { id: 2, label: 'Detail View', link: '/entity', element: <EntityDash /> },
     { id: 3, label: 'Global View', link: '/everything', element: <EverythingDash/> },
-    { id: 6, label: 'Signal Coefficients', link: '/view6', element: <View6 /> },
+    { id: 6, label: 'Chain Reactions', link: '/view6', element: <View6 /> },
     { id: 7, label: 'Isotopes', link: '/view7', element: <View7 /> },
   ];
 

--- a/protostar-react/src/pages/Home.tsx
+++ b/protostar-react/src/pages/Home.tsx
@@ -77,7 +77,7 @@ export function Home()
   return (
     <div className='bg-black text-white min-h-screen mt-20 px-4'>
       <div className='max-w-6xl mx-auto'>
-        <h1 className="text-3xl font-bold mt-4">Protostar: AI Powered Detection Management</h1>
+        <h1 className="text-3xl font-bold mt-4">Protostar: AI Powered Detection Lattices</h1>
         <h1 className="mt-4 flex-1">
         
           Tactical: An AI interface into detection elements by entity. From here, you can drilldown into the details of a detection element and ask questions of the AI interface<br></br><br></br>


### PR DESCRIPTION
## Neo4j query safety
- Bound unbounded `[*]` variable-length traversals that were pinning the DB, in both the Flask API (`telemetryservice.py`) and the protostar-neo browser views (View1/2/4/5 + entity-detail hook). Verified lossless against live data (view-1 reachability tops out at depth 2).

## View6 — network-connections graph (`view:6` overlay)
- New entity-centric graph: entities linked to the external peers they connect to (own host collapsed), plus entity-to-entity links (e.g. `LP-42 -> lp-sre-42`, where an endpoint and a cloud user share a host).
- Per-entity `connection_count` (distinct peers, incl. cloud `SEEN_FROM` sources).
- Directional arrows (cloud users are never a connection source, since they have only a source_ip); new `HOST` node type/color; entity-to-entity pairs highlighted red.

## View2 — signal/correlation highlight
- Entities with a `SIGNAL` or `*_CORRELATION` relationship render red (scoped to View2).

## Misc
- Label/spacing tweaks; Home.tsx.

> Note: the `view:6` graph data is materialized by `build_view6.py` (renamed from `build_view4.py`) in the separate **protostar-data** repo — that change is committed there separately.

Generated with [Claude Code](https://claude.com/claude-code)