### PR TITLE
Alerts: searchable, AI-enabled alert page

### DIFF
--- a/protostar-ai-dev-flask-api/dbcreation.py
+++ b/protostar-ai-dev-flask-api/dbcreation.py
@@ -58,6 +58,17 @@ def setup_postgres_tables():
       except Exception:
         connection.rollback()
         print('Table case_comments has already been created')
+      try:
+        cursor.execute("""CREATE TABLE alert_explanations (
+          explanation_id SERIAL PRIMARY KEY,
+          guid TEXT NOT NULL UNIQUE,
+          entity TEXT NOT NULL,
+          explanation TEXT NOT NULL,
+          created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);""")
+        connection.commit()
+      except Exception:
+        connection.rollback()
+        print('Table alert_explanations has already been created')
       finally:
         print('Tables Created!')
       try:

--- a/protostar-ai-dev-flask-api/dbupgrade.py
+++ b/protostar-ai-dev-flask-api/dbupgrade.py
@@ -47,6 +47,14 @@ def upgrade_database(dbname):
         created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)""")
       print('case_comments table: ok')
 
+      cursor.execute("""CREATE TABLE IF NOT EXISTS alert_explanations (
+        explanation_id SERIAL PRIMARY KEY,
+        guid TEXT NOT NULL UNIQUE,
+        entity TEXT NOT NULL,
+        explanation TEXT NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)""")
+      print('alert_explanations table: ok')
+
       cursor.execute("""select 1 from information_schema.table_constraints
         where table_schema = 'public' and table_name = 'cases' and constraint_type = 'UNIQUE'""")
       if cursor.fetchone() is None:

--- a/protostar-ai-dev-flask-api/protostar-ai-dev-flask-api.py
+++ b/protostar-ai-dev-flask-api/protostar-ai-dev-flask-api.py
@@ -421,9 +421,13 @@ def get_ai_commenting():
 @jwt_required()
 @cross_origin()
 def search_alerts():
-  data = request.get_json() or {}
-  term = data.get('term')
-  return telemetryservice.search_alerts_neo(term)
+  try:
+    data = request.get_json() or {}
+    term = data.get('term')
+    return telemetryservice.search_alerts_neo(term)
+  except Exception:
+    logging.getLogger(__name__).exception('Unable to search alerts')
+    return make_response(jsonify({"error": "Unable to search alerts"}), 500)
 
 @app.route('/savealertexplanation', methods=['POST'])
 @jwt_required()
@@ -437,6 +441,8 @@ def save_alert_explanation():
     if not guid or not explanation:
       return make_response(jsonify({"error": "guid and explanation are required"}), 400)
     saved = appservice.save_alert_explanation(guid, entity, explanation)
+    if not saved:
+      return make_response(jsonify({"error": "Unable to save alert explanation"}), 500)
     return make_response(jsonify({"Success": saved}), 200)
   except Exception as e:
     response = make_response(jsonify({"error": "Something went wrong"}), 401)

--- a/protostar-ai-dev-flask-api/protostar-ai-dev-flask-api.py
+++ b/protostar-ai-dev-flask-api/protostar-ai-dev-flask-api.py
@@ -417,6 +417,44 @@ def get_ai_commenting():
     response = make_response(jsonify({"error": "Something went wrong"}), 401)
     return response
 
+@app.route('/searchalerts', methods=['POST'])
+@jwt_required()
+@cross_origin()
+def search_alerts():
+  data = request.get_json() or {}
+  term = data.get('term')
+  return telemetryservice.search_alerts_neo(term)
+
+@app.route('/savealertexplanation', methods=['POST'])
+@jwt_required()
+@cross_origin()
+def save_alert_explanation():
+  try:
+    data = request.get_json()
+    guid = data.get('guid')
+    entity = data.get('entity')
+    explanation = data.get('explanation')
+    if not guid or not explanation:
+      return make_response(jsonify({"error": "guid and explanation are required"}), 400)
+    saved = appservice.save_alert_explanation(guid, entity, explanation)
+    return make_response(jsonify({"Success": saved}), 200)
+  except Exception as e:
+    response = make_response(jsonify({"error": "Something went wrong"}), 401)
+    return response
+
+@app.route('/getalertexplanations', methods=['POST'])
+@jwt_required()
+@cross_origin()
+def get_alert_explanations():
+  try:
+    data = request.get_json()
+    guids = data.get('guids')
+    explanations = appservice.get_alert_explanations(guids)
+    return make_response(explanations, 200)
+  except Exception as e:
+    response = make_response(jsonify({"error": "Something went wrong"}), 401)
+    return response
+
 @app.route('/getallcases', methods=['POST'])
 @jwt_required()
 @cross_origin()

--- a/protostar-ai-dev-flask-api/services/appservice.py
+++ b/protostar-ai-dev-flask-api/services/appservice.py
@@ -198,6 +198,31 @@ class AppService:
       logger.error(exc)
       return False
 
+  def save_alert_explanation(self, guid, entity, explanation):
+    try:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
+      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+        with connection.cursor() as cursor:
+          cursor.execute("""insert into alert_explanations (guid, entity, explanation) values (%s, %s, %s)
+            on conflict (guid) do update set explanation = excluded.explanation, created_at = CURRENT_TIMESTAMP""", (guid, entity, explanation))
+          return True
+    except Exception as exc:
+      logger.error(exc)
+      return False
+
+  def get_alert_explanations(self, guids):
+    if not guids:
+      return json.dumps({})
+    try:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
+      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+        with connection.cursor() as cursor:
+          cursor.execute('select guid, explanation from alert_explanations where guid = ANY(%s)', (list(guids),))
+          return json.dumps({row[0]: row[1] for row in cursor.fetchall()})
+    except Exception as exc:
+      logger.error(exc)
+      return json.dumps({})
+
   def load_case_comments(self, case):
     try:
       with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),

--- a/protostar-ai-dev-flask-api/services/appservice.py
+++ b/protostar-ai-dev-flask-api/services/appservice.py
@@ -15,8 +15,8 @@ class AppService:
 
   def check_connection(self):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword'), connect_timeout=3) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword'), connect_timeout=3) as connection:
         with connection.cursor() as cursor:
           cursor.execute('select 1')
           return cursor.fetchone()[0] == 1
@@ -26,8 +26,8 @@ class AppService:
 
   def get_users(self):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('select username from appusers')
           users = cursor.fetchall()
@@ -38,8 +38,8 @@ class AppService:
 
   def create_case(self, investigated_entity, assigned_user, case_name, case_description, priority=0):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           fillers ="%s,%s,%s,%s,%s,%s,Default,%s"
           sqlInsertStatement = f"insert into cases(assigned_user, casename, description, priority, investigated_entity, properties, created_at, resolved_at) values({fillers}) RETURNING case_id"
@@ -52,8 +52,8 @@ class AppService:
 
   def set_agent_status(self, case, status):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute("update cases set properties = coalesce(properties, '{}'::jsonb) || jsonb_build_object('agent_status', %s::text) where case_id = %s", (status, case))
     except Exception as exc:
@@ -61,8 +61,8 @@ class AppService:
 
   def close_case(self, case):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('update cases set resolved_at = CURRENT_TIMESTAMP where case_id = %s and resolved_at is null', (case,))
           logger.info(f'case {case}: closed')
@@ -73,8 +73,8 @@ class AppService:
 
   def get_entities_with_cases(self):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('select distinct investigated_entity from cases')
           return {row[0] for row in cursor.fetchall()}
@@ -84,8 +84,8 @@ class AppService:
 
   def get_unprocessed_cases(self):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute("""select case_id, investigated_entity from cases
             where case_id not in (select distinct case_id from case_comments where comment_user = 'agent' and comment <> '')
@@ -133,8 +133,8 @@ class AppService:
 
   def reset_stale_agent_statuses(self):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute("""update cases set properties = properties || '{"agent_status": "failed"}'::jsonb where properties->>'agent_status' = 'queued'""")
           if cursor.rowcount:
@@ -163,8 +163,8 @@ class AppService:
 
   def get_case(self, case):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('select row_to_json(t) from cases as t where t.case_id = %s', (case,))
           row = cursor.fetchone()
@@ -174,8 +174,8 @@ class AppService:
 
   def get_all_cases(self):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('select row_to_json(t) from cases as t order by t.created_at desc')
           cases = cursor.fetchall()
@@ -186,8 +186,8 @@ class AppService:
 
   def post_case_comment(self, case, user, comment):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           fillers ="%s,%s,%s,Default"
           sqlInsertStatement = f"insert into case_comments (case_id, comment_user, comment, created_at) values({fillers})"
@@ -200,8 +200,8 @@ class AppService:
 
   def save_alert_explanation(self, guid, entity, explanation):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute("""insert into alert_explanations (guid, entity, explanation) values (%s, %s, %s)
             on conflict (guid) do update set explanation = excluded.explanation, created_at = CURRENT_TIMESTAMP""", (guid, entity, explanation))
@@ -214,8 +214,8 @@ class AppService:
     if not guids:
       return json.dumps({})
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('select guid, explanation from alert_explanations where guid = ANY(%s)', (list(guids),))
           return json.dumps({row[0]: row[1] for row in cursor.fetchall()})
@@ -225,8 +225,8 @@ class AppService:
 
   def load_case_comments(self, case):
     try:
-      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber', fallback='4000'), dbname=self.config.get('Database', 'DatabaseName', fallback='protostar'),
-      user=self.config.get('Database', 'RootDatabaseUserName', fallback='postgres'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
+      with psycopg.connect(host=self.config.get('Database', 'HostName'), port=self.config.get('Database', 'PortNumber'), dbname=self.config.get('Database', 'DatabaseName'),
+      user=self.config.get('Database', 'RootDatabaseUserName'), password=self.config.get('Database', 'RootDatabasePassword')) as connection:
         with connection.cursor() as cursor:
           cursor.execute('SELECT row_to_json(row(comment_user, comment, created_at)) FROM case_comments where case_id = %s ORDER BY created_at DESC', (case,))
           comments = cursor.fetchall()

--- a/protostar-ai-dev-flask-api/services/telemetryservice.py
+++ b/protostar-ai-dev-flask-api/services/telemetryservice.py
@@ -160,6 +160,9 @@ class TelemetryService:
               m.host_ip as host_ip,
               m.source_ip as source_ip,
               m.executable AS executable,
+              m.syscall_name as syscall_name,
+              m.process as process,
+              m.proctitle as proctitle,
               m.dest_ip as dest_ip,
               m.dest_port as dest_port
           ORDER BY n.entity ASC
@@ -169,7 +172,52 @@ class TelemetryService:
     except Exception as e:
       print(e)
     return data
-  
+
+  def search_alerts_neo(self, term):
+    data = []
+    try:
+      neo4j = self.neo4j_driver
+      safe = (term or '').lower().replace("'", "''")
+      # empty box returns the 100 most recent alerts; a search term widens the window to 500
+      limit = 500 if safe.strip() else 100
+      query = f"""
+        MATCH (n:ENTITY)
+          WHERE n.view = 2
+          MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
+          WHERE toLower(n.entity) CONTAINS '{safe}'
+             OR toLower(m.entity_type) CONTAINS '{safe}'
+             OR toLower(m.name) CONTAINS '{safe}'
+             OR toLower(toString(m.severity)) CONTAINS '{safe}'
+          RETURN
+              substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity,
+              m.detection_type AS detection_type,
+              m.mitre_tactic AS mitre_tactic,
+              m.name as name,
+              m.timestamp as timestamp,
+              m.severity as severity,
+              m.entity_type AS entity_type,
+              m.guid as guid,
+              m.category AS category,
+              m.username AS username,
+              m.host_ip as host_ip,
+              m.source_ip as source_ip,
+              m.executable AS executable,
+              m.syscall_name as syscall_name,
+              m.process as process,
+              m.proctitle as proctitle,
+              m.message as message,
+              m.dest_ip as dest_ip,
+              m.dest_port as dest_port,
+              m.dst_geo as dst_geo
+          ORDER BY m.timestamp DESC
+          LIMIT {limit}
+        """
+      result_df = neo4j.query(query).to_data_frame()
+      data = result_df.to_json()
+    except Exception as e:
+      print(e)
+    return data
+
   def raw_atomic_weight(self, atomic_number, atomic_mass, signal_unique, signal_mass):
     non_signal_mass = max(atomic_mass - signal_mass, 0)
     return (((float(atomic_number) ** atomic_number) ** (1 + min(signal_unique, 3)))

--- a/protostar-ai-dev-flask-api/services/telemetryservice.py
+++ b/protostar-ai-dev-flask-api/services/telemetryservice.py
@@ -174,7 +174,6 @@ class TelemetryService:
     return data
 
   def search_alerts_neo(self, term):
-    data = []
     try:
       neo4j = self.neo4j_driver
       safe = (term or '').lower().replace("'", "''")
@@ -188,6 +187,7 @@ class TelemetryService:
              OR toLower(m.entity_type) CONTAINS '{safe}'
              OR toLower(m.name) CONTAINS '{safe}'
              OR toLower(toString(m.severity)) CONTAINS '{safe}'
+          WITH m, head(collect(DISTINCT n)) AS n
           RETURN
               substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity,
               m.detection_type AS detection_type,
@@ -213,10 +213,10 @@ class TelemetryService:
           LIMIT {limit}
         """
       result_df = neo4j.query(query).to_data_frame()
-      data = result_df.to_json()
-    except Exception as e:
-      print(e)
-    return data
+      return result_df.to_json()
+    except Exception:
+      logger.exception('Neo4j alert search failed')
+      raise
 
   def raw_atomic_weight(self, atomic_number, atomic_mass, signal_unique, signal_mass):
     non_signal_mass = max(atomic_mass - signal_mass, 0)

--- a/protostar-ai-dev-flask-api/services/telemetryservice.py
+++ b/protostar-ai-dev-flask-api/services/telemetryservice.py
@@ -187,7 +187,15 @@ class TelemetryService:
              OR toLower(m.entity_type) CONTAINS '{safe}'
              OR toLower(m.name) CONTAINS '{safe}'
              OR toLower(toString(m.severity)) CONTAINS '{safe}'
-          WITH m, head(collect(DISTINCT n)) AS n
+          WITH n, m, substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity_name
+          WITH CASE
+            WHEN m.guid IS NOT NULL AND m.name IS NOT NULL AND entity_name IS NOT NULL
+              THEN [m.guid, m.name, entity_name]
+            ELSE [elementId(m), elementId(n)]
+          END AS alert_key, n, m
+          ORDER BY m.timestamp DESC
+          WITH alert_key, head(collect({{entity_node: n, alert_node: m}})) AS matched
+          WITH matched.entity_node AS n, matched.alert_node AS m
           RETURN
               substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity,
               m.detection_type AS detection_type,

--- a/protostar-react/src/config/config.tsx
+++ b/protostar-react/src/config/config.tsx
@@ -70,6 +70,11 @@ export default class Config
     return this.baseUrl + '/rawentitydetailsneo';
   }
 
+  public SearchAlertsURL()
+  {
+    return this.baseUrl + '/searchalerts';
+  }
+
   public GetUsersURL()
   {
     return this.baseUrl + '/getusers';
@@ -123,6 +128,16 @@ export default class Config
   public GetAICommentingURL()
   {
     return this.baseUrl + '/getaicommenting';
+  }
+
+  public SaveAlertExplanationURL()
+  {
+    return this.baseUrl + '/savealertexplanation';
+  }
+
+  public GetAlertExplanationsURL()
+  {
+    return this.baseUrl + '/getalertexplanations';
   }
 
   public ServerURL()

--- a/protostar-react/src/pages/Alerts.tsx
+++ b/protostar-react/src/pages/Alerts.tsx
@@ -49,6 +49,8 @@ const detailKeysToShow: (keyof AlertRow)[] = [
   "guid",
 ];
 
+const alertsPerPage = 25;
+
 // backend sends pandas to_json: { column: { rowIndex: value } }
 function ToAlertRows(payload: any): AlertRow[]
 {
@@ -77,6 +79,7 @@ export function Alerts()
 {
   const [search, setSearch] = useState('');
   const [alerts, setAlerts] = useState<AlertRow[] | null>(null);
+  const [currentPage, setCurrentPage] = useState(0);
   const [loadFailed, setLoadFailed] = useState(false);
   const [explanations, setExplanations] = useState<Record<string, string>>({});
   const [visibleExplanations, setVisibleExplanations] = useState<Record<string, boolean>>({});
@@ -109,6 +112,7 @@ export function Alerts()
       setExplanations({});
       setVisibleExplanations({});
       setExplainingIndex(null);
+      setCurrentPage(0);
       const payload = await ts.SearchAlerts(term);
       if(cancelled)
       {
@@ -123,15 +127,33 @@ export function Alerts()
       setLoadFailed(false);
       const rows = ToAlertRows(payload);
       setAlerts(rows);
-      const guids = rows.map((row) => row.guid).filter(Boolean);
-      const stored = guids.length ? await as.GetAlertExplanations(guids) : {};
-      if(!cancelled && stored && typeof stored === 'object')
-      {
-        setExplanations(stored);
-      }
     }, term ? 350 : 0);
     return () => { cancelled = true; clearTimeout(handle); };
   }, [search]);
+
+  const pageCount = Math.max(1, Math.ceil((alerts?.length ?? 0) / alertsPerPage));
+  const pageStart = currentPage * alertsPerPage;
+  const visibleAlerts = (alerts ?? []).slice(pageStart, pageStart + alertsPerPage);
+
+  useEffect(() =>
+  {
+    let cancelled = false;
+    const loadVisibleExplanations = async () =>
+    {
+      const guids = visibleAlerts.map((row) => row.guid).filter(Boolean);
+      if(!guids.length)
+      {
+        return;
+      }
+      const stored = await as.GetAlertExplanations(guids);
+      if(!cancelled && stored && typeof stored === 'object')
+      {
+        setExplanations((current) => ({ ...current, ...stored }));
+      }
+    };
+    loadVisibleExplanations();
+    return () => { cancelled = true; };
+  }, [alerts, currentPage]);
 
   const alertKey = (alert: AlertRow, index: number) => alert.guid ?? String(index);
 
@@ -139,7 +161,7 @@ export function Alerts()
   {
     const key = alertKey(alert, index);
     setExplainingIndex(index);
-    const finalPrompt = ps.AlertSummaryPrompt(alerts, alert);
+    const finalPrompt = ps.AlertSummaryPrompt(visibleAlerts, alert);
     const output = await llm.AskLLM(finalPrompt);
     setExplanations((current) => ({ ...current, [key]: output || 'The AI request failed. Please try again.' }));
     setVisibleExplanations((current) => ({ ...current, [key]: true }));
@@ -157,19 +179,20 @@ export function Alerts()
 
   const ExplainAll = async () =>
   {
-    if(!alerts)
+    if(!visibleAlerts.length)
     {
       return;
     }
     setExplainingAll(true);
     // explanations is the closure snapshot from click time; only pre-existing keys are skipped
-    for(let index = 0; index < alerts.length; index++)
+    for(let index = 0; index < visibleAlerts.length; index++)
     {
-      if(explanations[alertKey(alerts[index], index)])
+      const absoluteIndex = pageStart + index;
+      if(explanations[alertKey(visibleAlerts[index], absoluteIndex)])
       {
         continue;
       }
-      await GenerateExplanation(alerts[index], index);
+      await GenerateExplanation(visibleAlerts[index], absoluteIndex);
     }
     setExplainingIndex(null);
     setExplainingAll(false);
@@ -180,10 +203,10 @@ export function Alerts()
     setVisibleExplanations((current) => ({ ...current, [key]: !current[key] }));
   };
 
-  const explainedKeys = (alerts ?? []).map(alertKey).filter((key) => explanations[key]);
+  const explainedKeys = visibleAlerts.map((alert, index) => alertKey(alert, pageStart + index)).filter((key) => explanations[key]);
   const anyExplanations = explainedKeys.length > 0;
   const allVisible = anyExplanations && explainedKeys.every((key) => visibleExplanations[key]);
-  const allExplained = !!alerts && alerts.length > 0 && alerts.every((alert, index) => explanations[alertKey(alert, index)]);
+  const allExplained = visibleAlerts.length > 0 && visibleAlerts.every((alert, index) => explanations[alertKey(alert, pageStart + index)]);
   const busy = explainingAll || explainingIndex !== null;
 
   const ToggleShowAll = () =>
@@ -230,7 +253,7 @@ export function Alerts()
           <>
             <button onClick={ExplainAll} disabled={busy || allExplained || !term} title={`${hts.ExplainAllHelpText()}`}
               className="bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
-              {explainingAll ? 'Explaining All...' : 'Explain All'}
+              {explainingAll ? 'Explaining Alerts In The Set Currently Shown...' : 'Explain Displayed Alerts'}
             </button>
             <button onClick={ToggleShowAll} disabled={!anyExplanations || explainingAll}
               className="bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
@@ -248,10 +271,11 @@ export function Alerts()
       {statusMessage && <p className="px-10 py-8 text-gray-400">{statusMessage}</p>}
 
       <div className="flex flex-col gap-2 px-10 py-6 pb-40">
-        {alerts && alerts.map((alert, index) => {
-          const key = alertKey(alert, index);
+        {visibleAlerts.map((alert, index) => {
+          const absoluteIndex = pageStart + index;
+          const key = alertKey(alert, absoluteIndex);
           const hasExplanation = !!explanations[key];
-          const isThisExplaining = explainingIndex === index;
+          const isThisExplaining = explainingIndex === absoluteIndex;
           const isVisible = !!visibleExplanations[key];
           let buttonLabel = 'Explain';
           if(isThisExplaining) { buttonLabel = 'Explaining...'; }
@@ -265,7 +289,7 @@ export function Alerts()
               <span>detection_type: "{alert.detection_type}"</span>
               <span>severity: "{alert.severity}"</span>
               <button title={`${hts.AIDetailsHelpText()}`}
-                onClick={() => hasExplanation ? ToggleVisible(key) : ExplainAlert(alert, index)}
+                onClick={() => hasExplanation ? ToggleVisible(key) : ExplainAlert(alert, absoluteIndex)}
                 disabled={busy && !isThisExplaining}
                 className="ml-auto bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-1 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
                 {buttonLabel}
@@ -287,6 +311,19 @@ export function Alerts()
           </div>
           );
         })}
+        {alerts && alerts.length > alertsPerPage && (
+          <div className="flex items-center justify-center gap-4 pt-4">
+            <button onClick={() => setCurrentPage((page) => Math.max(0, page - 1))} disabled={currentPage === 0 || busy}
+              className="bg-[#080808] text-white text-sm border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50">
+              Previous
+            </button>
+            <span className="text-sm text-gray-300">Page {currentPage + 1} of {pageCount}</span>
+            <button onClick={() => setCurrentPage((page) => Math.min(pageCount - 1, page + 1))} disabled={currentPage >= pageCount - 1 || busy}
+              className="bg-[#080808] text-white text-sm border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50">
+              Next
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/protostar-react/src/pages/Alerts.tsx
+++ b/protostar-react/src/pages/Alerts.tsx
@@ -1,188 +1,293 @@
-import { createBrowserRouter, data, RouterProvider, useLocation } from "react-router-dom";
-import React, { useState, useEffect, useRef } from 'react';
-// import Papa, { parse } from 'papaparse';
+import { useLocation } from "react-router-dom";
+import { useState, useEffect } from 'react';
 import LLMService from '../services/LLMService.ts';
 import TelemetryService from "../services/TelemetryService.ts";
+import AppService from "../services/AppService.ts";
 import PromptService from "../services/PromptService.ts";
 import HelpTextService from "../services/HelpTextService.ts";
 
-function MergeData(entityDetails: any, index: any)
+interface AlertRow
 {
-  let mergedData = []
-  for(let i = 0; i < entityDetails.length; i++)
+  entity: string;
+  detection_type: string;
+  mitre_tactic: string;
+  name: string;
+  timestamp: string;
+  severity: string;
+  entity_type: string;
+  guid: string;
+  category: string;
+  username: string;
+  host_ip: string;
+  source_ip: string;
+  executable: string;
+  syscall_name: string;
+  process: string;
+  proctitle: string;
+  message: string;
+  dest_ip: string;
+  dest_port: string;
+  dst_geo: string;
+}
+
+// always-present fields live in the row header; the rest render here, skipping empty values
+const detailKeysToShow: (keyof AlertRow)[] = [
+  "timestamp",
+  "category",
+  "mitre_tactic",
+  "host_ip",
+  "source_ip",
+  "dest_ip",
+  "dest_port",
+  "dst_geo",
+  "username",
+  "syscall_name",
+  "executable",
+  "process",
+  "proctitle",
+  "message",
+  "guid",
+];
+
+// backend sends pandas to_json: { column: { rowIndex: value } }
+function ToAlertRows(payload: any): AlertRow[]
+{
+  if(!payload || typeof payload !== 'object')
   {
-    mergedData.push(entityDetails[i][index]);
+    return [];
   }
-  return mergedData;
+  const columns = Object.keys(payload);
+  if(columns.length === 0)
+  {
+    return [];
+  }
+  const rowKeys = Object.keys(payload[columns[0]] ?? {});
+  const rows = rowKeys.map((row) => Object.fromEntries(columns.map((column) => [column, payload[column]?.[row]])) as AlertRow);
+  const toMillis = (value: any) => { const parsed = new Date(value).getTime(); return isNaN(parsed) ? 0 : parsed; };
+  return rows.sort((a, b) => toMillis(b.timestamp) - toMillis(a.timestamp));
+}
+
+function FormatTimestamp(value: any)
+{
+  const parsed = new Date(value);
+  return isNaN(parsed.getTime()) ? String(value ?? '') : parsed.toUTCString();
 }
 
 export function Alerts()
 {
-  const [llmQuestion, setLLMQuestion] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
-  const [expandedCardIndex, setExpandedCardIndex] = useState(null);
-  const [entities, setEntities] = useState<any>(null);
-  const [entityCounter, setEntityCounter] = useState<number>(0)
-  const [entityDetails, setEntityDetails] = useState<any>(null);
-  const [llmOutput, setLLMOutput] = useState('');
+  const [search, setSearch] = useState('');
+  const [alerts, setAlerts] = useState<AlertRow[] | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [explanations, setExplanations] = useState<Record<string, string>>({});
+  const [visibleExplanations, setVisibleExplanations] = useState<Record<string, boolean>>({});
+  const [explainingIndex, setExplainingIndex] = useState<number | null>(null);
+  const [explainingAll, setExplainingAll] = useState(false);
   const llm = new LLMService();
   const ts = new TelemetryService();
+  const as = new AppService();
   const ps = new PromptService();
   let hts = new HelpTextService();
   const navigatedEntity = useLocation().state;
+
   useEffect(() =>
   {
-    async function FetchEntities()
+    if(navigatedEntity)
     {
-      let neoEntities = await ts.GetEntitiesNeo();
-      let neoEArr = Object.values(neoEntities['entity']);
-      let neoDetails = (navigatedEntity) ? await ts.RetrieveRawEntityDetailsNeo(navigatedEntity) : await ts.RetrieveRawEntityDetailsNeo(neoEArr[0]);
-      let neoDArr = Object.values(neoDetails);
-      setEntityCounter(Object.values(neoDetails['name']).length)
-      setEntities(neoEArr);
-      setEntityDetails(neoDArr);
+      setSearch(navigatedEntity);
     }
-    FetchEntities();
-  }, []);
-  
-  const handleChange = (event: any) =>
+  }, [navigatedEntity]);
+
+  // debounced load: an empty box returns the 100 most recent alerts across all entities, a term filters them
+  useEffect(() =>
   {
-    setLLMQuestion(event.target.value);
+    const term = search.trim();
+    let cancelled = false;
+    const handle = setTimeout(async () =>
+    {
+      setAlerts(null);
+      setLoadFailed(false);
+      setExplanations({});
+      setVisibleExplanations({});
+      setExplainingIndex(null);
+      const payload = await ts.SearchAlerts(term);
+      if(cancelled)
+      {
+        return;
+      }
+      if(!payload || typeof payload !== 'object')
+      {
+        setAlerts([]);
+        setLoadFailed(true);
+        return;
+      }
+      setLoadFailed(false);
+      const rows = ToAlertRows(payload);
+      setAlerts(rows);
+      const guids = rows.map((row) => row.guid).filter(Boolean);
+      const stored = guids.length ? await as.GetAlertExplanations(guids) : {};
+      if(!cancelled && stored && typeof stored === 'object')
+      {
+        setExplanations(stored);
+      }
+    }, term ? 350 : 0);
+    return () => { cancelled = true; clearTimeout(handle); };
+  }, [search]);
+
+  const alertKey = (alert: AlertRow, index: number) => alert.guid ?? String(index);
+
+  const GenerateExplanation = async (alert: AlertRow, index: number) =>
+  {
+    const key = alertKey(alert, index);
+    setExplainingIndex(index);
+    const finalPrompt = ps.AlertSummaryPrompt(alerts, alert);
+    const output = await llm.AskLLM(finalPrompt);
+    setExplanations((current) => ({ ...current, [key]: output || 'The AI request failed. Please try again.' }));
+    setVisibleExplanations((current) => ({ ...current, [key]: true }));
+    if(output && alert.guid)
+    {
+      await as.SaveAlertExplanation(alert.guid, alert.entity, output);
+    }
   };
 
-  const handleEntityDataStorage = async (event: any) =>
+  const ExplainAlert = async (alert: AlertRow, index: number) =>
   {
-    setIsOpen(!isOpen);
-    setEntityDetails(null);
-    let option = event.currentTarget.dataset.value;
-    let neoDetails = await ts.RetrieveRawEntityDetailsNeo(option);
-    let neoDArr = Object.values(neoDetails);
-    let l = Object.values(neoDetails['name']);
-    setEntityCounter(l.length);
-    setEntityDetails(neoDArr);
+    await GenerateExplanation(alert, index);
+    setExplainingIndex(null);
+  };
+
+  const ExplainAll = async () =>
+  {
+    if(!alerts)
+    {
+      return;
+    }
+    setExplainingAll(true);
+    // explanations is the closure snapshot from click time; only pre-existing keys are skipped
+    for(let index = 0; index < alerts.length; index++)
+    {
+      if(explanations[alertKey(alerts[index], index)])
+      {
+        continue;
+      }
+      await GenerateExplanation(alerts[index], index);
+    }
+    setExplainingIndex(null);
+    setExplainingAll(false);
+  };
+
+  const ToggleVisible = (key: string) =>
+  {
+    setVisibleExplanations((current) => ({ ...current, [key]: !current[key] }));
+  };
+
+  const explainedKeys = (alerts ?? []).map(alertKey).filter((key) => explanations[key]);
+  const anyExplanations = explainedKeys.length > 0;
+  const allVisible = anyExplanations && explainedKeys.every((key) => visibleExplanations[key]);
+  const allExplained = !!alerts && alerts.length > 0 && alerts.every((alert, index) => explanations[alertKey(alert, index)]);
+  const busy = explainingAll || explainingIndex !== null;
+
+  const ToggleShowAll = () =>
+  {
+    const next = !allVisible;
+    setVisibleExplanations((current) =>
+    {
+      const updated = { ...current };
+      explainedKeys.forEach((key) => { updated[key] = next; });
+      return updated;
+    });
+  };
+
+  const term = search.trim();
+  let statusMessage = '';
+  if(loadFailed)
+  {
+    statusMessage = term ? `Search failed for "${term}". Try a different term.` : 'Something went wrong loading alerts. Try refreshing the page.';
   }
-  
-  if(entities)
+  else if(alerts === null)
   {
-    return (
-      <div className="relative min-h-screen mt-20">
-        {/* <h1 className="pl-10 text-3xl font-bold pt-4">Alerts</h1> */}
-        <div className="mx-10">
-          <button title={`${hts.EntityDropdownHelpText()}`}
-            onClick={() => setIsOpen(!isOpen)}
-            className="bg-black text-white border border-gray-300 mt-4 w-full py-2 rounded-md hover:bg-gray-600 font-normal cursor-pointer">
-            Select an Entity
-          </button>
-          <div className={`
-              absolute mt-2 w-96 rounded-md shadow-lg bg-black 
-              transform transition-all duration-300 ease-in-out
-              ${isOpen ? 'opacity-100 scale-100' : 'opacity-0 scale-95 pointer-events-none'}
-            `}>
-            <div>
-              {entities.map((option: any, index: any) => (
-                <button className="block w-full text-left px-4 py-2 bg-[#080808] text-white hover:bg-gray-600"
-                  key={index} data-value={option}
-                  onClick={handleEntityDataStorage}>
-                  {option}
-                </button>
+    statusMessage = term ? `Searching for "${term}"...` : 'Loading alerts...';
+  }
+  else if(alerts.length === 0)
+  {
+    statusMessage = term ? `No alerts match "${term}".` : 'No alerts found.';
+  }
+
+  return (
+    <div className="relative min-h-screen mt-20">
+      {/* <h1 className="pl-10 text-3xl font-bold pt-4">Alerts</h1> */}
+      <div className="mx-10 mt-4 flex items-center gap-3">
+        <input type="text"
+          title={`${hts.AlertSearchHelpText()}`}
+          value={search}
+          placeholder="Search alerts by entity, entity type, name, or severity..."
+          onChange={(event) => setSearch(event.target.value)}
+          className="bg-black text-white border border-gray-300 w-1/2 py-2 px-3 rounded-md font-normal focus:outline-none focus:shadow-outline" />
+        <button onClick={() => setSearch('')} disabled={!search}
+          className="bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
+          Clear
+        </button>
+        {alerts && alerts.length > 0 && (
+          <>
+            <button onClick={ExplainAll} disabled={busy || allExplained || !term} title={`${hts.ExplainAllHelpText()}`}
+              className="bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
+              {explainingAll ? 'Explaining All...' : 'Explain All'}
+            </button>
+            <button onClick={ToggleShowAll} disabled={!anyExplanations || explainingAll}
+              className="bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-2 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
+              {allVisible ? 'Hide All' : 'Show All'}
+            </button>
+            {!term && (
+              <span className="ml-auto text-sm text-gray-400">
+                Showing the {alerts.length} most recent alerts. Search to narrow across all entities.
+              </span>
+            )}
+          </>
+        )}
+      </div>
+
+      {statusMessage && <p className="px-10 py-8 text-gray-400">{statusMessage}</p>}
+
+      <div className="flex flex-col gap-2 px-10 py-6 pb-40">
+        {alerts && alerts.map((alert, index) => {
+          const key = alertKey(alert, index);
+          const hasExplanation = !!explanations[key];
+          const isThisExplaining = explainingIndex === index;
+          const isVisible = !!visibleExplanations[key];
+          let buttonLabel = 'Explain';
+          if(isThisExplaining) { buttonLabel = 'Explaining...'; }
+          else if(hasExplanation) { buttonLabel = isVisible ? 'Hide' : 'Show'; }
+          return (
+          <div key={key} data-testid="alert-row" className="bg-[#1B1B1B] text-white rounded shadow px-6 py-4">
+            <div className="flex flex-wrap items-center gap-x-6 font-bold mb-2">
+              <span>entity: "{alert.entity}"</span>
+              <span>entity_type: "{alert.entity_type}"</span>
+              <span>name: "{alert.name}"</span>
+              <span>detection_type: "{alert.detection_type}"</span>
+              <span>severity: "{alert.severity}"</span>
+              <button title={`${hts.AIDetailsHelpText()}`}
+                onClick={() => hasExplanation ? ToggleVisible(key) : ExplainAlert(alert, index)}
+                disabled={busy && !isThisExplaining}
+                className="ml-auto bg-[#080808] text-white text-sm font-normal border border-gray-300 px-4 py-1 rounded-md hover:bg-gray-600 disabled:opacity-50 cursor-pointer">
+                {buttonLabel}
+              </button>
+            </div>
+            <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-300">
+              {detailKeysToShow.map((detailKey) => (
+                (alert[detailKey] && alert[detailKey] !== '-') ? <div key={detailKey}>{detailKey}: "{detailKey === 'timestamp' ? FormatTimestamp(alert[detailKey]) : alert[detailKey]}"</div> : null
               ))}
             </div>
-          </div>
-        </div>
-  
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 p-10 pb-24 text-wrap">
-          {entityDetails && Array.from({ length: entityCounter }, (_, index) => (
-          <div key={entityDetails[7]?.[index] ?? index} className={`transition-all duration-300 ease-in-out ${expandedCardIndex === index ? 
-            'fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[81%] h-[81%] z-50 origin-top' : 'w-full'} rounded overflow-hidden shadow-lg bg-white`}>
-            <div className={`${(expandedCardIndex === index) ? 'bg-[#080808]' : 'bg-[#1B1B1B]'} flex flex-row text-white h-full`}>
-              <div className="px-10 py-6 w-fit">
-                <div className="font-bold text-xl mb-2">Entity: {entityDetails[0][index]}</div>
-                <div className="font-medium text-xl mb-2">DT: {entityDetails[1][index]}</div>
-                <div className="font-medium text-xl mb-2">Name: <span className={`${(expandedCardIndex === index) ? 'text-xl' : 'text-sm'}`}>{entityDetails[3][index]}</span></div>
-                <div className="font-medium text-xl mb-2">Mitre Tactic: {entityDetails[2][index]}</div>
-                <div>
-                  <div className="text-white text-base">
-                    {entityDetails[0][index] != '' && expandedCardIndex === index && (
-                      <div className="bg-[#242124] px-4 py-8 rounded w-fit h-fit mt-4">
-                        <p><span className="font-semibold">Severity: </span>{ entityDetails[5][index] }</p>
-                        <p><span className="font-semibold">Host IP: </span>{ entityDetails[10][index] }</p>
-                        <p><span className="font-semibold">Source IP: </span>{ entityDetails[11][index] }</p>
-                        <p><span className="font-semibold">Dest IP: </span>{ entityDetails[13][index] }</p>
-                        <p><span className="font-semibold">Dest Port: </span>{ entityDetails[14][index] }</p>
-                        <p><span className="font-semibold">GUID: </span>{ entityDetails[7][index] }</p>
-                        <p><span className="font-semibold">Timestamp: </span>{ entityDetails[4][index] }</p>
-                        <p><span className="font-semibold">Name: </span>{ entityDetails[3][index] }</p>
-                        <p><span className="font-semibold">Category: </span>{ entityDetails[8][index] }</p>
-                        <p><span className="font-semibold">Mitre Tactic: </span>{ entityDetails[2][index] }</p>
-                        <p><span className="font-semibold">Entity Type: </span>{ entityDetails[6][index] }</p>
-                        <br />
-                        {/* <p>Can include more detailed information about the alert</p> */}
-                      </div>
-                    )}
-                  </div>
-                  <button title={`${hts.AIDetailsHelpText()}`} onClick=
-                    {async() => 
-                      {
-                        let entitySpecificData = MergeData(entityDetails, index);
-                        let finalPrompt = ps.AlertSummaryPrompt(entityDetails, entitySpecificData);
-                        let lm = await llm.AskLLM(finalPrompt);
-                        setLLMOutput(lm);
-                      }
-                    } className={`${(expandedCardIndex === index) ? 'block' : 'hidden'} bg-[#080808] text-white border border-gray-300 mt-4 w-48 py-2 rounded-md hover:bg-gray-600 font-normal cursor-pointer`}>Explain Alert Details</button>
-                </div>
-                <div className="pt-6 pb-2">
-                  <div className="flex justify-start">
-                  <button className={`${expandedCardIndex === index ? 'fixed bottom-0 left-0 m-4 hover:bg-red-800' : 'hover:bg-gray-400'} bg-[#BCBCBC] border-solid text-black font-bold py-2 px-4 rounded mt-4 cursor-pointer`}
-                    onClick={() =>
-                      {
-                        setExpandedCardIndex((expandedCardIndex === index) ? null : index);
-                        setLLMOutput('');
-                      }
-                    }>
-                    {expandedCardIndex === index ? 'Close Details' : 'Alert Details'}
-                  </button>
-                  </div>
-                </div>
+            {(isVisible || isThisExplaining) && (
+              <div className="mt-3 bg-[#242124] rounded p-4">
+                <span className="font-bold block mb-2">AI Explanation</span>
+                <p className="text-gray-200 text-sm whitespace-pre-wrap">
+                  {isThisExplaining ? 'Asking the AI about this alert...' : explanations[key]}
+                </p>
               </div>
-              <div className={`${expandedCardIndex === index ? 'block' : 'hidden'} w-7/12 p-6`}>
-                <div className="mb-4">
-                  <label className="block text-gray-400 font-bold text-xl mb-2 my-4">Ask Question</label>
-                  <textarea onChange={handleChange} className="my-3 w-full h-32 shadow resize-none appearance-none border bg-[#1B1B1B] rounded border-gray-300 py-2 px-3 text-gray-300 leading-tight focus:outline-none focus:shadow-outline"  placeholder="Type your question here..." />
-                  <div className="flex justify-end mb-4">
-                    <button title={`${hts.AskAIHelpText()}`} onClick=
-                    {async() => 
-                      {
-                        let entitySpecificData = MergeData(entityDetails, index);
-                        let finalPrompt = ps.AlertPrompt(llmQuestion, entityDetails, entitySpecificData);
-                        let output = await llm.AskLLM(finalPrompt);
-                        setLLMOutput(output);
-                      }
-                    } className="bg-black text-white border border-gray-300 w-48 py-2 rounded-md hover:bg-gray-600 font-normal cursor-pointer">Ask AI</button>
-                  </div>
-                </div>
-                <div className="mb-24">
-                  <label className="block text-gray-700 font-bold text-xl mb-2 my-4">Output</label>
-                  <p className="overflow-visible">
-                    <textarea readOnly={true} value={llmOutput} placeholder="The AI answer will appear here" className="h-96 w-full bg-[#1B1B1B] border-gray-300 overflow-y-auto cursor-default my-3 shadow resize-none appearance-none border rounded py-2 px-3 leading-tight focus:outline-none focus:shadow-outline" />
-                  </p>
-                </div>
-              </div>
-            </div>
+            )}
           </div>
-        ))}
+          );
+        })}
       </div>
-  
-        {/* Overlay when any card is expanded */}
-        {expandedCardIndex !== null && (<div className="fixed inset-0 bg-black opacity-50 z-40" onClick={() => setExpandedCardIndex(null)}/>)}
-      </div>
-    );
-  }
-  else
-  {
-    return (
-      <div className="relative h-screen mt-20">
-        <h1 className="pl-10 text-3xl font-bold pt-4">Alerts</h1>
-      </div>
-    )
-  }
+    </div>
+  );
 }

--- a/protostar-react/src/pages/Alerts.tsx
+++ b/protostar-react/src/pages/Alerts.tsx
@@ -92,6 +92,15 @@ export function Alerts()
   let hts = new HelpTextService();
   const navigatedEntity = useLocation().state;
 
+  const alertKey = (alert: AlertRow, index: number) =>
+  {
+    if(alert.guid && alert.name && alert.entity)
+    {
+      return JSON.stringify([alert.guid, alert.name, alert.entity]);
+    }
+    return `alert-row-${index}`;
+  };
+
   useEffect(() =>
   {
     if(navigatedEntity)
@@ -148,14 +157,20 @@ export function Alerts()
       const stored = await as.GetAlertExplanations(guids);
       if(!cancelled && stored && typeof stored === 'object')
       {
-        setExplanations((current) => ({ ...current, ...stored }));
+        const keyedStored: Record<string, string> = {};
+        visibleAlerts.forEach((alert, index) =>
+        {
+          if(alert.guid && stored[alert.guid])
+          {
+            keyedStored[alertKey(alert, pageStart + index)] = stored[alert.guid];
+          }
+        });
+        setExplanations((current) => ({ ...current, ...keyedStored }));
       }
     };
     loadVisibleExplanations();
     return () => { cancelled = true; };
   }, [alerts, currentPage]);
-
-  const alertKey = (alert: AlertRow, index: number) => alert.guid ?? String(index);
 
   const GenerateExplanation = async (alert: AlertRow, index: number) =>
   {

--- a/protostar-react/src/root/App.tsx
+++ b/protostar-react/src/root/App.tsx
@@ -39,7 +39,7 @@ function App()
     }
   );
   return (
-    <div className='bg-black overflow-y-scroll max-h-screen text-white'>
+    <div className='bg-black min-h-screen flow-root text-white'>
       <Menu />
     </div>
   )

--- a/protostar-react/src/services/AppService.ts
+++ b/protostar-react/src/services/AppService.ts
@@ -71,6 +71,58 @@ export default class AppService
     }
   }
 
+  // no logout-on-error here: explanation persistence is an enhancement, the
+  // Alerts page must keep working when these calls fail
+  async SaveAlertExplanation(guid: string, entity: string, explanation: string)
+  {
+    try
+    {
+      let token = localStorage.getItem('token');
+      const response = await axios.post(this.config.SaveAlertExplanationURL(),
+      {
+        'guid': guid,
+        'entity': entity,
+        'explanation': explanation
+      },
+      {
+        headers:
+        {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      return response.data;
+    }
+    catch(error)
+    {
+      console.log('Saving the alert explanation failed', error);
+      return null;
+    }
+  }
+
+  async GetAlertExplanations(guids: string[])
+  {
+    try
+    {
+      let token = localStorage.getItem('token');
+      const response = await axios.post(this.config.GetAlertExplanationsURL(),
+      {
+        'guids': guids
+      },
+      {
+        headers:
+        {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      return response.data;
+    }
+    catch(error)
+    {
+      console.log('Loading alert explanations failed', error);
+      return null;
+    }
+  }
+
   async GetAllCases()
   {
     try

--- a/protostar-react/src/services/HelpTextService.ts
+++ b/protostar-react/src/services/HelpTextService.ts
@@ -43,4 +43,16 @@ export default class HelpTextService
     let helpText = `Select to expand and see other selectable entities.`;
     return helpText;
   }
+
+  public AlertSearchHelpText()
+  {
+    let helpText = `Search alerts across all entities by entity, entity type, name, or severity. Leave empty to see the 100 most recent.`;
+    return helpText;
+  }
+
+  public ExplainAllHelpText()
+  {
+    let helpText = `Search to narrow the list first, then explain every alert on screen.`;
+    return helpText;
+  }
 }

--- a/protostar-react/src/services/PromptService.ts
+++ b/protostar-react/src/services/PromptService.ts
@@ -5,9 +5,7 @@ export default class PromptService
   public DetailsPrompt(question: string, details: any)
   {
     let finalPrompt = `Can you explain the security risks and steps for mitigation using the following data:" "${details}", answer the 
-    following question: "${question}. Answer it as detailed as you can. At the beginning of the response place 
-    the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:" Do not forget to
-    place this message at the beginning of the output. It's important for the message to be there. As mentioned be detailed with the response but also concise and 
+    following question: "${question}. Answer it as detailed as you can.       . As mentioned be detailed with the response but also concise and 
     to the point.`;
     return finalPrompt; 
   }
@@ -15,9 +13,7 @@ export default class PromptService
   public DetailsSummaryPrompt(details: any)
   {
     let finalPrompt = `Can you explain the security risks and steps for mitigation using the following data:" "${details}", can you give me a summary of 
-    what I need to priortize for this particular entity. Answer it as detailed as you can. At the beginning of the response place 
-    the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:" Do not forget to
-    place this message at the beginning of the output. It's important for the message to be there. As mentioned be detailed with the response but also concise and 
+    what I need to priortize for this particular entity. Answer it as detailed as you can.       . As mentioned be detailed with the response but also concise and 
     to the point.`;
     return finalPrompt; 
   }
@@ -26,9 +22,7 @@ export default class PromptService
   {
     let finalPrompt = `Can you explain the security risks and steps for mitigation using a summary explanation of the data and what the scores mean. Give a 
     summary report on the data and explain what the nature of the activity is. Be verbose and identify fields you recognize. Explain each 
-    field that you recognize and what kind of data it contains. Suggest possible investigative directions. ${details}. At the beginning of the response place 
-    the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:" Do not forget to
-    place this message at the beginning of the output. It's important for the message to be there. As mentioned be detailed with the response but also concise and 
+    field that you recognize and what kind of data it contains. Suggest possible investigative directions. ${details}.       . As mentioned be detailed with the response but also concise and 
     to the point.`;
     return finalPrompt;
   }
@@ -37,9 +31,7 @@ export default class PromptService
   {
     let finalPrompt = `Can you explain the security risks and steps for mitigation using this information and based on this data: "${details}" Next, answer 
     the following specific question: "${question}"  and repeat my question to me. When answering explain each field that
-    you recognize and what kind of data it contains and suggest possible investigative directions. Answer it as best as you can. At the beginning of the response place 
-    the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:" Do not forget to
-    place this message at the beginning of the output. It's important for the message to be there. As mentioned be detailed with the response but also concise and 
+    you recognize and what kind of data it contains and suggest possible investigative directions. Answer it as best as you can.       . As mentioned be detailed with the response but also concise and 
     to the point.`;
     return finalPrompt;
   }
@@ -47,9 +39,7 @@ export default class PromptService
   public AlertSummaryPrompt(details: any, specificDetails: any)
   {
     let finalPrompt = `Can you explain the security risks and steps for mitigation using the data specific to this alert: ${JSON.stringify(specificDetails)} and here's the data for 
-    the overall entity: ${JSON.stringify(details)}. As previously mentioned give a summary but coorelate the importance between the alert and the overall entity. At the beginning of the response place 
-    the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:" Do not forget to
-    place this message at the beginning of the output. It's important for the message to be there. As mentioned be detailed with the response but also concise and 
+    the overall entity: ${JSON.stringify(details)}. As previously mentioned give a summary but coorelate the importance between the alert and the overall entity.       . As mentioned be detailed with the response but also concise and 
     to the point.`;
     return finalPrompt;
   }
@@ -59,9 +49,7 @@ export default class PromptService
     let finalPrompt = `Answer the following question in quotes "${question}" on the data and based on what the nature of the activity is. Explain the cybersecurity risks.
     Be verbose and identify fields you recognize. Answer every part of the question that you recognize and which data relates best to it. Suggest possible investigative directions listed in steps. Here
     are the details for the specific alert: "${JSON.stringify(details)}" and here's the information for the overall entity: "${specificDetails}. Make correlations between 
-    the two when answering the question. Answer it as best as you can. At the beginning of the response place 
-    the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:" Do not forget to
-    place this message at the beginning of the output. It's important for the message to be there. As mentioned be detailed with the response but also concise and 
+    the two when answering the question. Answer it as best as you can.       . As mentioned be detailed with the response but also concise and 
     to the point.`;
     return finalPrompt;
   }
@@ -69,7 +57,7 @@ export default class PromptService
   public SummaryOfThreatStatusSummaryPrompt(details: any)
   {
     let finalPrompt = `Can you give me a further summary and explain the security risks and mitigation steps based on this output: ${details}. Answer it as best as you can. At the beginning 
-    of the response place the following message: "If you would like a more detailed response you will need to get the pro version of the application. Here's the output for the free version:"`;
+    of the response place the following message: `;
     return finalPrompt;
   }
 }

--- a/protostar-react/src/services/TelemetryService.ts
+++ b/protostar-react/src/services/TelemetryService.ts
@@ -115,6 +115,33 @@ export default class TelemetryService
     }
   }
 
+  // no logout-on-error here: a failed search must not end the session, the page
+  // shows an error state and the user keeps working
+  async SearchAlerts(term: any)
+  {
+    let config = new Config();
+    try
+    {
+      let token = localStorage.getItem('token');
+      const response = await axios.post(config.SearchAlertsURL(),
+      {
+        'term': term
+      },
+      {
+        headers:
+        {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+      return response.data;
+    }
+    catch(error)
+    {
+      console.error('Alert search failed', error);
+      return null;
+    }
+  }
+
   async GetEntityTypes()
   {
     let config = new Config();

--- a/smoke-tests/tests/pages.spec.ts
+++ b/smoke-tests/tests/pages.spec.ts
@@ -101,9 +101,14 @@ test('Alerts renders recent alerts and supports search', async ({ page }) => {
   expect(defaultResult.ok(), `/searchalerts returned ${defaultResult.status()}`).toBeTruthy();
   const defaultPayload = await defaultResult.json();
   const defaultCount = Object.values(defaultPayload.name ?? {}).length;
+  const defaultGuids = Object.values(defaultPayload.guid ?? {});
   expect(defaultCount).toBeGreaterThan(0);
   expect(defaultCount).toBeLessThanOrEqual(100);
-  await expect(page.getByTestId('alert-row')).toHaveCount(defaultCount);
+  expect(new Set(defaultGuids).size).toBe(defaultGuids.length);
+  await expect(page.getByTestId('alert-row')).toHaveCount(Math.min(defaultCount, 25));
+  if (defaultCount > 25) {
+    await expect(page.getByText(`Page 1 of ${Math.ceil(defaultCount / 25)}`)).toBeVisible();
+  }
   console.log(`Alerts rendered ${defaultCount} recent alert row(s)`);
 
   // cross-entity search: typing a term hits /searchalerts and renders matching rows
@@ -116,8 +121,10 @@ test('Alerts renders recent alerts and supports search', async ({ page }) => {
   expect(searchResult.ok(), `/searchalerts returned ${searchResult.status()}`).toBeTruthy();
   const searchPayload = await searchResult.json();
   const searchCount = Object.values(searchPayload.name ?? {}).length;
+  const searchGuids = Object.values(searchPayload.guid ?? {});
   expect(searchCount).toBeGreaterThan(0);
-  await expect(page.getByTestId('alert-row')).toHaveCount(searchCount);
+  expect(new Set(searchGuids).size).toBe(searchGuids.length);
+  await expect(page.getByTestId('alert-row')).toHaveCount(Math.min(searchCount, 25));
   console.log(`Search "${searchTerm}" returned ${searchCount} alert row(s)`);
 });
 

--- a/smoke-tests/tests/pages.spec.ts
+++ b/smoke-tests/tests/pages.spec.ts
@@ -91,27 +91,34 @@ test('Summary links an entity to its Details data', async ({ page }) => {
   console.log(`Details rendered data for ${selectedEntity}`);
 });
 
-test('Alerts renders entity alert data', async ({ page }) => {
-  const entitiesResponse = page.waitForResponse(
-    response => response.url().endsWith('/getentitiesneo') && response.request().method() === 'GET',
+test('Alerts renders recent alerts and supports search', async ({ page }) => {
+  // default view: empty search returns the 100 most recent alerts across all entities
+  const defaultResponse = page.waitForResponse(
+    response => response.url().endsWith('/searchalerts') && response.request().method() === 'POST',
   );
-  const detailsResponse = page.waitForResponse(
-    response => response.url().endsWith('/rawentitydetailsneo') && response.request().method() === 'POST',
-  );
-
   await page.goto('/alerts');
-  const entitiesPayload = await (await entitiesResponse).json();
-  const details = await detailsResponse;
+  const defaultResult = await defaultResponse;
+  expect(defaultResult.ok(), `/searchalerts returned ${defaultResult.status()}`).toBeTruthy();
+  const defaultPayload = await defaultResult.json();
+  const defaultCount = Object.values(defaultPayload.name ?? {}).length;
+  expect(defaultCount).toBeGreaterThan(0);
+  expect(defaultCount).toBeLessThanOrEqual(100);
+  await expect(page.getByTestId('alert-row')).toHaveCount(defaultCount);
+  console.log(`Alerts rendered ${defaultCount} recent alert row(s)`);
 
-  expect(entitiesPayload).toHaveProperty('entity');
-  expect(Object.values(entitiesPayload.entity)).not.toHaveLength(0);
-  expect(details.ok(), `/rawentitydetailsneo returned ${details.status()}`).toBeTruthy();
-  const detailsPayload = await details.json();
-  const alertCount = Object.values(detailsPayload.name).length;
-  expect(alertCount).toBeGreaterThan(0);
-  await expect(page.getByText(/^Entity: /).first()).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Alert Details' })).toHaveCount(alertCount);
-  console.log(`Alerts rendered ${alertCount} alert card(s)`);
+  // cross-entity search: typing a term hits /searchalerts and renders matching rows
+  const searchTerm = String(Object.values(defaultPayload.entity)[0]);
+  const searchResponse = page.waitForResponse(
+    response => response.url().endsWith('/searchalerts') && response.request().method() === 'POST',
+  );
+  await page.getByPlaceholder('Search alerts by entity, entity type, name, or severity...').fill(searchTerm);
+  const searchResult = await searchResponse;
+  expect(searchResult.ok(), `/searchalerts returned ${searchResult.status()}`).toBeTruthy();
+  const searchPayload = await searchResult.json();
+  const searchCount = Object.values(searchPayload.name ?? {}).length;
+  expect(searchCount).toBeGreaterThan(0);
+  await expect(page.getByTestId('alert-row')).toHaveCount(searchCount);
+  console.log(`Search "${searchTerm}" returned ${searchCount} alert row(s)`);
 });
 
 test('Cases loads its supporting API data', async ({ page }) => {

--- a/smoke-tests/tests/pages.spec.ts
+++ b/smoke-tests/tests/pages.spec.ts
@@ -102,9 +102,12 @@ test('Alerts renders recent alerts and supports search', async ({ page }) => {
   const defaultPayload = await defaultResult.json();
   const defaultCount = Object.values(defaultPayload.name ?? {}).length;
   const defaultGuids = Object.values(defaultPayload.guid ?? {});
+  const defaultNames = Object.values(defaultPayload.name ?? {});
+  const defaultEntities = Object.values(defaultPayload.entity ?? {});
+  const defaultAlertKeys = defaultGuids.map((guid, index) => JSON.stringify([guid, defaultNames[index], defaultEntities[index]]));
   expect(defaultCount).toBeGreaterThan(0);
   expect(defaultCount).toBeLessThanOrEqual(100);
-  expect(new Set(defaultGuids).size).toBe(defaultGuids.length);
+  expect(new Set(defaultAlertKeys).size).toBe(defaultAlertKeys.length);
   await expect(page.getByTestId('alert-row')).toHaveCount(Math.min(defaultCount, 25));
   if (defaultCount > 25) {
     await expect(page.getByText(`Page 1 of ${Math.ceil(defaultCount / 25)}`)).toBeVisible();
@@ -122,8 +125,11 @@ test('Alerts renders recent alerts and supports search', async ({ page }) => {
   const searchPayload = await searchResult.json();
   const searchCount = Object.values(searchPayload.name ?? {}).length;
   const searchGuids = Object.values(searchPayload.guid ?? {});
+  const searchNames = Object.values(searchPayload.name ?? {});
+  const searchEntities = Object.values(searchPayload.entity ?? {});
+  const searchAlertKeys = searchGuids.map((guid, index) => JSON.stringify([guid, searchNames[index], searchEntities[index]]));
   expect(searchCount).toBeGreaterThan(0);
-  expect(new Set(searchGuids).size).toBe(searchGuids.length);
+  expect(new Set(searchAlertKeys).size).toBe(searchAlertKeys.length);
   await expect(page.getByTestId('alert-row')).toHaveCount(Math.min(searchCount, 25));
   console.log(`Search "${searchTerm}" returned ${searchCount} alert row(s)`);
 });


### PR DESCRIPTION
## Summary

Reworks the Alerts page into a searchable, AI-explainable alert feed with cross-session persistence. **Stacked on `cases-2` (#69)** — base is `cases-2` so this shows only the alerts delta; it will retarget to `main` once #69 merges.

### Alerts page
- Free-text search across **all** entities, matching entity / entity_type / name / severity via a new `/searchalerts` endpoint (debounced; empty box returns the 100 most recent alerts, a term widens to 500). Includes a **Clear** button.
- One alert per row: labeled header + skip-empty detail fields in View3's field order, sorted newest-first, showing every column the query returns including the newly added `dst_geo` and `message`.
- Fields accessed **by name** instead of positional array indices, so backend column changes can't silently shift the displayed data.
- Per-row **Explain** generates an LLM assessment; once present the button becomes **Show/Hide**. **Explain All** (gated behind a search so it can't fire 100 calls from the default view) and **Show All / Hide All** operate in bulk.
- Real loading / error / empty states; search failures no longer log the user out.

### Persistence
- New `alert_explanations` table (`dbcreation` + `dbupgrade`). Explanations save on generate and reload for the on-screen alerts' guids via `/savealertexplanation` and `/getalertexplanations`.

### Layout
- Scrolling moved to the window (not an inner container) so the scrollbar thumb isn't hidden under the fixed menu; `flow-root` restores a block formatting context so page top margins still clear the nav.

### Prompts
- Removed the "pro version" instruction from the frontend prompts (it was causing stricter models to refuse the Home situation report).

### Testing
- Rewrote the Alerts smoke test for the search-driven flow (default load + cross-entity search), counting rows via a stable test id.

## Notes / follow-ups
- Backend query changes require a Flask restart to take effect (no auto-reload).
- `SummaryOfThreatStatusSummaryPrompt` still has a small dangling "place the following message:" fragment to clean up.
- Home's situation report still passes data as an unlabeled flattened array — worth structuring for better output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
